### PR TITLE
Update build.gradle to include SSO services in BOM

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -29,6 +29,7 @@ dependencies {
     
     implementation('software.amazon.awssdk:codeartifact')
     implementation('software.amazon.awssdk:sts')
+    implementation('software.amazon.awssdk:sso')
 
     testImplementation('org.junit.jupiter:junit-jupiter-api')
     testRuntimeOnly('org.junit.jupiter:junit-jupiter-engine')


### PR DESCRIPTION
In order for AWS SSO profiles to be able to be used, the SSO service needs to be available on the classpath.

Fixes clarityai-eng/codeartifact-gradle-plugin#124