### PR TITLE
feat(deps): add aws-ssooidc dependency

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -28,6 +28,7 @@ dependencies {
   implementation(libs.aws.codeartifact)
   implementation(libs.aws.sts)
   implementation(libs.aws.sso)
+  implementation(libs.aws.ssooidc)
 
   // Use the Kotlin Test integration.
   testImplementation(libs.kotlin.tests)

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -16,6 +16,7 @@ aws-bom = { module = "software.amazon.awssdk:bom", version.ref = "aws-sdk" }
 aws-codeartifact = { module = "software.amazon.awssdk:codeartifact" }
 aws-sts = { module = "software.amazon.awssdk:sts" }
 aws-sso = { module = "software.amazon.awssdk:sso" }
+aws-ssooidc = { module = "software.amazon.awssdk:ssooidc" }
 
 # Testing libraries
 kotlin-tests = { module = "org.jetbrains.kotlin:kotlin-test" }


### PR DESCRIPTION
Fix SSO OIDC dependency for AWS SDK auth

This change adds the missing AWS SDK ssooidc dependency required when using SSO-based authentication profiles (OIDC) with CodeArtifact.

Without this module, Gradle fails during repository configuration with:

`ClassNotFoundException: software.amazon.awssdk.services.ssooidc.SsoOidcProfileTokenProviderFactory`

The issue occurs when resolving credentials from AWS SSO profiles using OIDC (e.g. sso_session configuration in `~/.aws/config)`, where the AWS SDK v2 requires the ssooidc service module to be present on the classpath.

**Why this change is needed:**
- AWS SDK v2 splits SSO and SSO OIDC into separate modules
- The plugin currently assumes only core SSO support is available
- Environments using AWS SSO (OIDC) fail during Gradle configuration phase

**Impact:**
- Enables support for AWS SSO (OIDC) profiles
- Fixes Gradle build failures when using sso_session authentication
- No impact on non-SSO authentication flows