### PR TITLE
test: add missing unit and functional test coverage

### DIFF
--- a/src/functionalTest/kotlin/ai/clarity/codeartifact/ClarityCodeArtifactGradlePluginFunctionalTest.kt
+++ b/src/functionalTest/kotlin/ai/clarity/codeartifact/ClarityCodeArtifactGradlePluginFunctionalTest.kt
@@ -17,15 +17,19 @@
 
 package ai.clarity.codeartifact
 
+import com.sun.net.httpserver.HttpServer
 import org.assertj.core.api.Assertions.assertThat
 import org.gradle.testkit.runner.GradleRunner
 import org.gradle.testkit.runner.TaskOutcome
+import org.junit.jupiter.api.AfterEach
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Nested
+import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.io.TempDir
 import org.junit.jupiter.params.ParameterizedTest
 import org.junit.jupiter.params.provider.MethodSource
 import java.io.File
+import java.net.InetSocketAddress
 
 private const val codeArtifactUrl =
   "https://my-domain-111122223333.d.codeartifact.us-west-2.amazonaws.com/maven/my-repo/"
@@ -334,6 +338,191 @@ class ClarityCodeartifactPluginFunctionalTest {
         .forwardOutput()
         .withPluginClasspath()
         .withProjectDir(projectDir)
+    }
+  }
+
+  @Nested
+  inner class GroovyDslFunctionalTest {
+
+    @TempDir
+    lateinit var projectDir: File
+
+    private val buildFile by lazy { File(projectDir, "build.gradle") }
+    private val settingsFile by lazy { File(projectDir, "settings.gradle") }
+
+    @BeforeEach
+    fun setUp() {
+      settingsFile.writeText("rootProject.name = 'test-groovy-project'")
+    }
+
+    @ParameterizedTest(name = "Gradle {0}")
+    @MethodSource("ai.clarity.codeartifact.ClarityCodeartifactPluginFunctionalTest#gradleVersions")
+    fun `plugin configures credentials via Groovy DSL codeartifact method`(gradleVersion: String) {
+      // Given: a Groovy build file that uses the codeartifact(...) dynamic method
+      buildFile.writeText(
+        """
+        plugins {
+            id 'ai.clarity.codeartifact'
+        }
+
+        repositories {
+            codeartifact('$codeArtifactUrl')
+        }
+        """.trimIndent()
+      )
+
+      // When: running the build (expecting a failure due to missing AWS credentials)
+      val result = createRunner(gradleVersion)
+        .withArguments("help", "--info")
+        .buildAndFail()
+
+      // Then: the failure confirms the Groovy DSL method tried to fetch a CodeArtifact token
+      assertThat(result.output).containsIgnoringCase("Getting token for $codeArtifactUrl in profile default")
+    }
+
+    @ParameterizedTest(name = "Gradle {0}")
+    @MethodSource("ai.clarity.codeartifact.ClarityCodeartifactPluginFunctionalTest#gradleVersions")
+    fun `plugin configures credentials via Groovy DSL codeartifact method with profile and closure`(gradleVersion: String) {
+      // Given: a Groovy build file that uses codeartifact(...) with a profile and a configuration closure
+      buildFile.writeText(
+        """
+        plugins {
+            id 'ai.clarity.codeartifact'
+        }
+
+        repositories {
+            codeartifact('$codeArtifactUrl', 'my-profile') {
+                name = 'customCodeArtifactRepo'
+            }
+        }
+        """.trimIndent()
+      )
+
+      // When: running the build (expecting a failure due to missing AWS credentials)
+      val result = createRunner(gradleVersion)
+        .withArguments("help", "--info")
+        .buildAndFail()
+
+      // Then: the failure confirms the requested profile reached the token fetch
+      assertThat(result.output).containsIgnoringCase("Getting token for $codeArtifactUrl in profile my-profile")
+    }
+
+    @ParameterizedTest(name = "Gradle {0}")
+    @MethodSource("ai.clarity.codeartifact.ClarityCodeartifactPluginFunctionalTest#gradleVersions")
+    fun `plugin attempts to configure credentials for maven repositories declared in Groovy DSL`(gradleVersion: String) {
+      // Given: a Groovy build file relying on automatic detection of the CodeArtifact URL
+      buildFile.writeText(
+        """
+        plugins {
+            id 'ai.clarity.codeartifact'
+        }
+
+        repositories {
+            maven {
+                url = uri('$codeArtifactUrl')
+            }
+        }
+        """.trimIndent()
+      )
+
+      // When: running the build (expecting a failure due to missing AWS credentials)
+      val result = createRunner(gradleVersion)
+        .withArguments("help", "--info")
+        .buildAndFail()
+
+      // Then: the failure confirms the plugin detected the repository and tried to fetch a token
+      assertThat(result.output).containsIgnoringCase("Getting token for $codeArtifactUrl in profile")
+    }
+
+    private fun createRunner(gradleVersion: String): GradleRunner {
+      return GradleRunner.create()
+        .withGradleVersion(gradleVersion)
+        .forwardOutput()
+        .withPluginClasspath()
+        .withProjectDir(projectDir)
+    }
+  }
+
+  @Nested
+  inner class TokenEndpointFunctionalTest {
+
+    @TempDir
+    lateinit var projectDir: File
+
+    private val buildFile by lazy { File(projectDir, "build.gradle.kts") }
+    private val settingsFile by lazy { File(projectDir, "settings.gradle.kts") }
+
+    private lateinit var server: HttpServer
+
+    @BeforeEach
+    fun setUp() {
+      settingsFile.writeText("""rootProject.name = "test-token-endpoint"""")
+
+      // Stub of the CodeArtifact GetAuthorizationToken endpoint
+      server = HttpServer.create(InetSocketAddress("127.0.0.1", 0), 0)
+      server.createContext("/") { exchange ->
+        val body = """{"authorizationToken":"stub-token","expiration":1893456000}"""
+        val bytes = body.toByteArray()
+        exchange.responseHeaders.add("Content-Type", "application/json")
+        exchange.sendResponseHeaders(200, bytes.size.toLong())
+        exchange.responseBody.use { it.write(bytes) }
+      }
+      server.start()
+    }
+
+    @AfterEach
+    fun tearDown() {
+      server.stop(0)
+    }
+
+    @Test
+    fun `plugin fetches the token from the codeartifact endpoint and configures credentials`() {
+      // Given: a build file relying on automatic detection of the CodeArtifact URL
+      buildFile.writeText(
+        $$"""
+        plugins {
+            id("ai.clarity.codeartifact")
+        }
+
+        repositories {
+            maven {
+                url = uri("$$codeArtifactUrl")
+            }
+        }
+
+        tasks.register("printRepoCredentials") {
+            doLast {
+                val repo = project.repositories.first() as org.gradle.api.artifacts.repositories.MavenArtifactRepository
+                println("username=${repo.credentials.username}")
+                println("password=${repo.credentials.password}")
+            }
+        }
+        """.trimIndent()
+      )
+
+      // The AWS SDK resolves the service endpoint and static credentials from these variables,
+      // so the token request hits the local stub instead of AWS
+      val environment = System.getenv()
+        .minus(listOf("AWS_PROFILE", "CODEARTIFACT_PROFILE", "AWS_SESSION_TOKEN")) +
+        mapOf(
+          "AWS_ENDPOINT_URL_CODEARTIFACT" to "http://127.0.0.1:${server.address.port}",
+          "AWS_ACCESS_KEY_ID" to "test-access-key",
+          "AWS_SECRET_ACCESS_KEY" to "test-secret-key",
+        )
+
+      // When: running a build with the environment pointing to the stub
+      val result = GradleRunner.create()
+        .forwardOutput()
+        .withPluginClasspath()
+        .withProjectDir(projectDir)
+        .withEnvironment(environment)
+        .withArguments("printRepoCredentials")
+        .build()
+
+      // Then: the repository ends up configured with the stubbed token
+      assertThat(result.output).contains("username=aws")
+      assertThat(result.output).contains("password=stub-token")
+      assertThat(result.task(":printRepoCredentials")?.outcome).isEqualTo(TaskOutcome.SUCCESS)
     }
   }
 }

--- a/src/test/java/ai/clarity/codeartifact/CodeArtifactUrlTest.java
+++ b/src/test/java/ai/clarity/codeartifact/CodeArtifactUrlTest.java
@@ -16,6 +16,7 @@
 package ai.clarity.codeartifact;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import java.net.MalformedURLException;
 import org.junit.jupiter.api.Test;
@@ -35,6 +36,24 @@ class CodeArtifactUrlTest {
   }
 
   @Test
+  void testOfWithUrlWithMultiHyphenDomain() throws MalformedURLException {
+    // when
+    CodeArtifactUrl url = CodeArtifactUrl.of("https://my-domain-111122223333.d.codeartifact.us-west-2.amazonaws.com/maven/my-repo/");
+
+    // then
+    assertThat(url.getRegion()).isEqualTo("us-west-2");
+    assertThat(url.getArtifactDomain()).isEqualTo("my-domain");
+    assertThat(url.getArtifactOwner()).isEqualTo("111122223333");
+    assertThat(url.getPath()).isEqualTo("/maven/my-repo/");
+  }
+
+  @Test
+  void testOfWithInvalidUrl() {
+    assertThatThrownBy(() -> CodeArtifactUrl.of("not a valid url"))
+      .isInstanceOf(MalformedURLException.class);
+  }
+
+  @Test
   void testOfWithURLSegments() throws MalformedURLException {
     // Given
     String artifactDomain = "domain";
@@ -44,6 +63,15 @@ class CodeArtifactUrlTest {
 
     // When
     CodeArtifactUrl url = CodeArtifactUrl.of(artifactDomain, artifactOwner, region, path);
+
+    // Then
+    assertThat(url.getUrl()).hasToString("https://domain-owner.d.codeartifact.eu-west-2.amazonaws.com/maven/releases/");
+  }
+
+  @Test
+  void testOfWithURLSegmentsNormalizesPathWithoutLeadingSlash() throws MalformedURLException {
+    // When
+    CodeArtifactUrl url = CodeArtifactUrl.of("domain", "owner", "eu-west-2", "maven/releases");
 
     // Then
     assertThat(url.getUrl()).hasToString("https://domain-owner.d.codeartifact.eu-west-2.amazonaws.com/maven/releases/");

--- a/src/test/java/ai/clarity/codeartifact/URIBuilderTest.java
+++ b/src/test/java/ai/clarity/codeartifact/URIBuilderTest.java
@@ -114,4 +114,32 @@ class URIBuilderTest {
     assertThat(builder.getQueryParamValue("foo")).isNull();
     assertThat(builder.toURI()).isEqualTo(uri);
   }
+
+  @Test
+  void testExplicitPort() throws URISyntaxException {
+    URI uri = URI.create("http://www.acme.com:8080/test/path?foo=bar");
+    URIBuilder builder = URIBuilder.of(uri);
+
+    assertThat(builder.getPort()).isEqualTo(8080);
+    assertThat(builder.toURI()).isEqualTo(uri);
+  }
+
+  @Test
+  void testParamWithEmptyValue() throws URISyntaxException {
+    URI uri = URI.create("https://www.acme.com/test/path?foo=");
+    URIBuilder builder = URIBuilder.of(uri);
+
+    assertThat(builder.getQueryParamValue("foo")).isEmpty();
+    assertThat(builder.toURI()).isEqualTo(uri);
+  }
+
+  @Test
+  void testWithQueryStripsLeadingQuestionMark() throws URISyntaxException {
+    URIBuilder builder = URIBuilder.of(URI.create("https://www.acme.com/test/path"))
+      .withQuery("?foo=bar&baz=qux");
+
+    assertThat(builder.getQueryParamValue("foo")).isEqualTo("bar");
+    assertThat(builder.getQueryParamValue("baz")).isEqualTo("qux");
+    assertThat(builder.getQuery()).isEqualTo("foo=bar&baz=qux");
+  }
 }

--- a/src/test/kotlin/ai/clarity/codeartifact/CodeArtifactProjectPluginTest.kt
+++ b/src/test/kotlin/ai/clarity/codeartifact/CodeArtifactProjectPluginTest.kt
@@ -6,6 +6,7 @@ import io.mockk.unmockkAll
 import io.mockk.verify
 import org.assertj.core.api.Assertions.assertThat
 import org.gradle.api.artifacts.repositories.MavenArtifactRepository
+import org.gradle.api.publish.PublishingExtension
 import org.gradle.testfixtures.ProjectBuilder
 import org.junit.jupiter.api.AfterEach
 import org.junit.jupiter.api.Test
@@ -18,6 +19,7 @@ class CodeArtifactProjectPluginTest {
   @AfterEach
   fun tearDown() {
     unmockkAll()
+    System.clearProperty("codeartifact.profile")
   }
 
   @Test
@@ -65,6 +67,177 @@ class CodeArtifactProjectPluginTest {
     // Then
     assertThat(repository.credentials.username).isNull()
     assertThat(repository.credentials.password).isNull()
+  }
+
+  @Test
+  fun `plugin uses profile from url query param and removes it from the repository url`() {
+    // Given
+    val mockResponse = GetAuthorizationTokenResponse.builder()
+      .authorizationToken("mock-token-ci")
+      .build()
+
+    mockkStatic(TokenFactory::class)
+    every { TokenFactory.getAuthorizationToken(any<CodeArtifactUrl>(), "ci-profile") } returns mockResponse
+
+    val project = ProjectBuilder.builder().build()
+    project.plugins.apply("ai.clarity.codeartifact")
+
+    val codeArtifactUrl = "https://my-domain-111122223333.d.codeartifact.us-west-2.amazonaws.com/maven/my-repo/"
+
+    // When
+    project.repositories.maven { repo ->
+      repo.url = URI("$codeArtifactUrl?profile=ci-profile")
+    }
+    val repository = project.repositories.first() as MavenArtifactRepository
+
+    // Then
+    assertThat(repository.url).isEqualTo(URI(codeArtifactUrl))
+    assertThat(repository.credentials.username).isEqualTo("aws")
+    assertThat(repository.credentials.password).isEqualTo("mock-token-ci")
+
+    verify(exactly = 1) { TokenFactory.getAuthorizationToken(any<CodeArtifactUrl>(), "ci-profile") }
+  }
+
+  @Test
+  fun `plugin uses the codeartifact profile system property as default profile`() {
+    // Given
+    System.setProperty("codeartifact.profile", "sysprop-profile")
+
+    val mockResponse = GetAuthorizationTokenResponse.builder()
+      .authorizationToken("mock-token-sysprop")
+      .build()
+
+    mockkStatic(TokenFactory::class)
+    every { TokenFactory.getAuthorizationToken(any<CodeArtifactUrl>(), "sysprop-profile") } returns mockResponse
+
+    val project = ProjectBuilder.builder().build()
+    project.plugins.apply("ai.clarity.codeartifact")
+
+    val codeArtifactUrl = "https://my-domain-111122223333.d.codeartifact.us-west-2.amazonaws.com/maven/my-repo/"
+
+    // When
+    project.repositories.maven { repo ->
+      repo.url = URI(codeArtifactUrl)
+    }
+    val repository = project.repositories.first() as MavenArtifactRepository
+
+    // Then
+    assertThat(repository.credentials.username).isEqualTo("aws")
+    assertThat(repository.credentials.password).isEqualTo("mock-token-sysprop")
+
+    verify(exactly = 1) { TokenFactory.getAuthorizationToken(any<CodeArtifactUrl>(), "sysprop-profile") }
+  }
+
+  @Test
+  fun `profile from url query param has precedence over the system property`() {
+    // Given
+    System.setProperty("codeartifact.profile", "sysprop-profile")
+
+    val mockResponse = GetAuthorizationTokenResponse.builder()
+      .authorizationToken("mock-token-url")
+      .build()
+
+    mockkStatic(TokenFactory::class)
+    every { TokenFactory.getAuthorizationToken(any<CodeArtifactUrl>(), "url-profile") } returns mockResponse
+
+    val project = ProjectBuilder.builder().build()
+    project.plugins.apply("ai.clarity.codeartifact")
+
+    val codeArtifactUrl = "https://my-domain-111122223333.d.codeartifact.us-west-2.amazonaws.com/maven/my-repo/"
+
+    // When
+    project.repositories.maven { repo ->
+      repo.url = URI("$codeArtifactUrl?profile=url-profile")
+    }
+    val repository = project.repositories.first() as MavenArtifactRepository
+
+    // Then
+    assertThat(repository.credentials.password).isEqualTo("mock-token-url")
+    verify(exactly = 1) { TokenFactory.getAuthorizationToken(any<CodeArtifactUrl>(), "url-profile") }
+    verify(exactly = 0) { TokenFactory.getAuthorizationToken(any<CodeArtifactUrl>(), "sysprop-profile") }
+  }
+
+  @Test
+  fun `plugin configures credentials for publishing repositories when maven-publish is applied`() {
+    // Given
+    val mockResponse = GetAuthorizationTokenResponse.builder()
+      .authorizationToken("mock-token-publish")
+      .build()
+
+    mockkStatic(TokenFactory::class)
+    every { TokenFactory.getAuthorizationToken(any<CodeArtifactUrl>(), any()) } returns mockResponse
+
+    val project = ProjectBuilder.builder().build()
+    project.plugins.apply("ai.clarity.codeartifact")
+    project.plugins.apply("maven-publish")
+
+    val codeArtifactUrl = "https://my-domain-111122223333.d.codeartifact.us-west-2.amazonaws.com/maven/my-repo/"
+
+    // When
+    val publishing = project.extensions.getByType(PublishingExtension::class.java)
+    publishing.repositories.maven { repo ->
+      repo.url = URI(codeArtifactUrl)
+    }
+    val repository = publishing.repositories.first() as MavenArtifactRepository
+
+    // Then
+    assertThat(repository.credentials.username).isEqualTo("aws")
+    assertThat(repository.credentials.password).isEqualTo("mock-token-publish")
+
+    verify(exactly = 1) { TokenFactory.getAuthorizationToken(any<CodeArtifactUrl>(), any()) }
+  }
+
+  @Test
+  fun `plugin skips codeartifact repositories with existing credentials`() {
+    // Given
+    mockkStatic(TokenFactory::class)
+
+    val project = ProjectBuilder.builder().build()
+    project.plugins.apply("ai.clarity.codeartifact")
+
+    val codeArtifactUrl = "https://my-domain-111122223333.d.codeartifact.us-west-2.amazonaws.com/maven/my-repo/"
+
+    // When
+    project.repositories.maven { repo ->
+      repo.url = URI(codeArtifactUrl)
+      repo.credentials { creds ->
+        creds.username = "existing-user"
+        creds.password = "existing-pass"
+      }
+    }
+    val repository = project.repositories.first() as MavenArtifactRepository
+
+    // Then
+    assertThat(repository.credentials.username).isEqualTo("existing-user")
+    assertThat(repository.credentials.password).isEqualTo("existing-pass")
+
+    verify(exactly = 0) { TokenFactory.getAuthorizationToken(any<CodeArtifactUrl>(), any()) }
+  }
+
+  @Test
+  fun `plugin detects codeartifact urls case-insensitively`() {
+    // Given
+    val mockResponse = GetAuthorizationTokenResponse.builder()
+      .authorizationToken("mock-token-case")
+      .build()
+
+    mockkStatic(TokenFactory::class)
+    every { TokenFactory.getAuthorizationToken(any<CodeArtifactUrl>(), any()) } returns mockResponse
+
+    val project = ProjectBuilder.builder().build()
+    project.plugins.apply("ai.clarity.codeartifact")
+
+    val codeArtifactUrl = "https://my-domain-111122223333.d.CodeArtifact.us-west-2.amazonaws.com/maven/my-repo/"
+
+    // When
+    project.repositories.maven { repo ->
+      repo.url = URI(codeArtifactUrl)
+    }
+    val repository = project.repositories.first() as MavenArtifactRepository
+
+    // Then
+    assertThat(repository.credentials.username).isEqualTo("aws")
+    assertThat(repository.credentials.password).isEqualTo("mock-token-case")
   }
 
 }

--- a/src/test/kotlin/ai/clarity/codeartifact/CodeArtifactTokenTest.kt
+++ b/src/test/kotlin/ai/clarity/codeartifact/CodeArtifactTokenTest.kt
@@ -1,0 +1,121 @@
+/*
+ * Copyright 2020-2026 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+
+package ai.clarity.codeartifact
+
+import io.mockk.every
+import io.mockk.mockkStatic
+import io.mockk.unmockkAll
+import io.mockk.verify
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.AfterEach
+import org.junit.jupiter.api.Test
+import software.amazon.awssdk.services.codeartifact.model.GetAuthorizationTokenResponse
+import java.net.URI
+
+class CodeArtifactTokenTest {
+
+  private val codeArtifactUrl = "https://my-domain-111122223333.d.codeartifact.us-west-2.amazonaws.com/maven/my-repo/"
+
+  @AfterEach
+  fun tearDown() {
+    unmockkAll()
+  }
+
+  @Test
+  fun `token is fetched only once for the same url and profile`() {
+    // Given
+    mockkStatic(TokenFactory::class)
+    every { TokenFactory.getAuthorizationToken(any<CodeArtifactUrl>(), "default") } returns
+      GetAuthorizationTokenResponse.builder().authorizationToken("tok-1").build()
+
+    val service = CodeArtifactToken()
+
+    // When
+    val first = service.getToken(codeArtifactUrl, "default")
+    val second = service.getToken(codeArtifactUrl, "default")
+
+    // Then
+    assertThat(first).isEqualTo("tok-1")
+    assertThat(second).isEqualTo("tok-1")
+    verify(exactly = 1) { TokenFactory.getAuthorizationToken(any<CodeArtifactUrl>(), "default") }
+  }
+
+  @Test
+  fun `token is fetched separately for each profile on the same url`() {
+    // Given
+    mockkStatic(TokenFactory::class)
+    every { TokenFactory.getAuthorizationToken(any<CodeArtifactUrl>(), "dev") } returns
+      GetAuthorizationTokenResponse.builder().authorizationToken("tok-dev").build()
+    every { TokenFactory.getAuthorizationToken(any<CodeArtifactUrl>(), "prod") } returns
+      GetAuthorizationTokenResponse.builder().authorizationToken("tok-prod").build()
+
+    val service = CodeArtifactToken()
+
+    // When
+    val devToken = service.getToken(codeArtifactUrl, "dev")
+    val prodToken = service.getToken(codeArtifactUrl, "prod")
+
+    // Then
+    assertThat(devToken).isEqualTo("tok-dev")
+    assertThat(prodToken).isEqualTo("tok-prod")
+    verify(exactly = 1) { TokenFactory.getAuthorizationToken(any<CodeArtifactUrl>(), "dev") }
+    verify(exactly = 1) { TokenFactory.getAuthorizationToken(any<CodeArtifactUrl>(), "prod") }
+  }
+
+  @Test
+  fun `token is fetched separately for each url on the same profile`() {
+    // Given
+    val otherUrl = "https://other-domain-444455556666.d.codeartifact.eu-west-1.amazonaws.com/maven/other-repo/"
+
+    mockkStatic(TokenFactory::class)
+    every { TokenFactory.getAuthorizationToken(any<CodeArtifactUrl>(), "default") } returnsMany listOf(
+      GetAuthorizationTokenResponse.builder().authorizationToken("tok-1").build(),
+      GetAuthorizationTokenResponse.builder().authorizationToken("tok-2").build()
+    )
+
+    val service = CodeArtifactToken()
+
+    // When
+    val first = service.getToken(codeArtifactUrl, "default")
+    val second = service.getToken(otherUrl, "default")
+
+    // Then
+    assertThat(first).isEqualTo("tok-1")
+    assertThat(second).isEqualTo("tok-2")
+    verify(exactly = 2) { TokenFactory.getAuthorizationToken(any<CodeArtifactUrl>(), "default") }
+  }
+
+  @Test
+  fun `getToken accepts a URI and shares the cache with the string overload`() {
+    // Given
+    mockkStatic(TokenFactory::class)
+    every { TokenFactory.getAuthorizationToken(any<CodeArtifactUrl>(), "default") } returns
+      GetAuthorizationTokenResponse.builder().authorizationToken("tok-uri").build()
+
+    val service = CodeArtifactToken()
+
+    // When
+    val fromUri = service.getToken(URI(codeArtifactUrl), "default")
+    val fromString = service.getToken(codeArtifactUrl, "default")
+
+    // Then
+    assertThat(fromUri).isEqualTo("tok-uri")
+    assertThat(fromString).isEqualTo("tok-uri")
+    verify(exactly = 1) { TokenFactory.getAuthorizationToken(any<CodeArtifactUrl>(), "default") }
+  }
+}


### PR DESCRIPTION
## Summary

Closes the main test-coverage gaps found while reviewing the plugin. No production code changes — tests only.

### Unit tests

- **`CodeArtifactTokenTest`** (new): the shared build service token cache — a single `TokenFactory` call per url+profile, separate fetches per profile and per url, and the `URI` overload sharing the cache with the `String` one.
- **`CodeArtifactProjectPluginTest`**: profile resolution via the `?profile=` query param including the url rewrite that strips it, `codeartifact.profile` system property as default profile and its precedence below the query param, credentials injection into `publishing.repositories` when `maven-publish` is applied, repositories with pre-existing credentials being left untouched, and case-insensitive CodeArtifact url detection.
- **`CodeArtifactUrlTest`**: multi-hyphen domain parsing (`my-domain-111122223333`), `MalformedURLException` on invalid urls, path normalization without a leading slash.
- **`URIBuilderTest`**: explicit port, empty param value (`foo=`), query with a leading `?`.

### Functional tests (Gradle TestKit)

- **`GroovyDslFunctionalTest`** (new nested class): the dynamic `codeartifact()` method from a Groovy `build.gradle` — plain, with profile plus configuration closure, and automatic detection of `maven {}` repositories — across all supported Gradle versions. This DSL had no coverage at all (only the Kotlin variant was tested).
- **`TokenEndpointFunctionalTest`** (new nested class): a full green-path end-to-end run without a real AWS account. A local JDK `HttpServer` stubs the `GetAuthorizationToken` endpoint and is wired in through `AWS_ENDPOINT_URL_CODEARTIFACT` and static env credentials, proving the plugin fetches the token and injects it as repository credentials.

## Test plan

- [x] `./gradlew test` — 33 tests, 0 failures
- [x] `./gradlew check` (includes `functionalTest`) — 56 functional tests, 0 failures

🤖 Generated with [Claude Code](https://claude.com/claude-code)