### PR TITLE
fix: reject invalid CodeArtifact repository URLs with a descriptive error

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -26,7 +26,7 @@ jobs:
         run: ./gradlew build
 
       - name: Publish Test Report
-        uses: scacap/action-surefire-report@v1.12.0
+        uses: ScalableCapital/action-surefire-report@v2.0.4
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
-          report_paths: '**/build/test-results/test/TEST-*.xml'
+          report_paths: '**/build/test-results/**/TEST-*.xml'

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -63,7 +63,7 @@ configurations["functionalTestImplementation"].extendsFrom(configurations["testI
 configurations["functionalTestRuntimeOnly"].extendsFrom(configurations["testRuntimeOnly"])
 
 // Add a task to run the functional tests
-val functionalTest by tasks.registering(Test::class) {
+val functionalTest = tasks.register<Test>("functionalTest") {
   testClassesDirs = functionalTestSourceSet.output.classesDirs
   classpath = functionalTestSourceSet.runtimeClasspath
   useJUnitPlatform()

--- a/src/main/java/ai/clarity/codeartifact/CodeArtifactUrl.java
+++ b/src/main/java/ai/clarity/codeartifact/CodeArtifactUrl.java
@@ -19,8 +19,21 @@ import java.net.MalformedURLException;
 import java.net.URI;
 import java.net.URISyntaxException;
 import java.net.URL;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
 
 class CodeArtifactUrl {
+
+  // Accepts the public CodeArtifact repository hosts, both the standard endpoint
+  // ({domain}-{owner}.d.codeartifact.{region}.amazonaws.com) and the dualstack one
+  // ({domain}-{owner}.d.codeartifact.{region}.on.aws). VPC endpoints
+  // (vpce-*.d.codeartifact.{region}.vpce.amazonaws.com) carry the domain and owner in
+  // the path instead of the host and are not supported.
+  private static final Pattern HOST_PATTERN = Pattern.compile(
+    "(?i)^([^.]+)-([^-.]+)\\.d\\.codeartifact\\.([^.]+)\\.(?:amazonaws\\..+|on\\.aws)$");
+
+  private static final String EXPECTED_FORMAT =
+    "https://{domain}-{owner}.d.codeartifact.{region}.amazonaws.com/{format}/{repository}/";
 
   private final URL url;
   private final String artifactDomain;
@@ -28,13 +41,17 @@ class CodeArtifactUrl {
   private final String region;
   private final String path;
 
-  public CodeArtifactUrl(URL url) {
+  public CodeArtifactUrl(URL url) throws MalformedURLException {
+    Matcher host = HOST_PATTERN.matcher(url.getHost());
+    if (!host.matches()) {
+      throw new MalformedURLException(
+        "Not a valid CodeArtifact repository URL: " + url + " (expected format: " + EXPECTED_FORMAT + ")");
+    }
     this.url = url;
-    String[] domainLevels = this.url.getHost().split("\\.");
     path = url.getPath();
-    artifactDomain = domainLevels[0].substring(0, domainLevels[0].lastIndexOf("-"));
-    artifactOwner = domainLevels[0].substring(domainLevels[0].lastIndexOf("-") + 1);
-    region = domainLevels[domainLevels.length - 3];
+    artifactDomain = host.group(1);
+    artifactOwner = host.group(2);
+    region = host.group(3);
   }
 
   public CodeArtifactUrl(String artifactDomain, String artifactOwner, String region, String path) throws MalformedURLException {
@@ -62,7 +79,7 @@ class CodeArtifactUrl {
     return new CodeArtifactUrl(artifactDomain, artifactOwner, region, path);
   }
 
-  public static CodeArtifactUrl of(URL url) {
+  public static CodeArtifactUrl of(URL url) throws MalformedURLException {
     return new CodeArtifactUrl(url);
   }
 

--- a/src/test/java/ai/clarity/codeartifact/CodeArtifactUrlTest.java
+++ b/src/test/java/ai/clarity/codeartifact/CodeArtifactUrlTest.java
@@ -54,6 +54,53 @@ class CodeArtifactUrlTest {
   }
 
   @Test
+  void testOfWithDualstackUrl() throws MalformedURLException {
+    // when
+    CodeArtifactUrl url = CodeArtifactUrl.of("https://my-domain-111122223333.d.codeartifact.us-west-2.on.aws/maven/my-repo/");
+
+    // then
+    assertThat(url.getRegion()).isEqualTo("us-west-2");
+    assertThat(url.getArtifactDomain()).isEqualTo("my-domain");
+    assertThat(url.getArtifactOwner()).isEqualTo("111122223333");
+    assertThat(url.getPath()).isEqualTo("/maven/my-repo/");
+  }
+
+  @Test
+  void testOfWithHostWithoutOwner() {
+    assertThatThrownBy(() -> CodeArtifactUrl.of("https://mydomain.d.codeartifact.eu-west-1.amazonaws.com/maven/repository/"))
+      .isInstanceOf(MalformedURLException.class)
+      .hasMessageContaining("Not a valid CodeArtifact repository URL")
+      .hasMessageContaining("https://mydomain.d.codeartifact.eu-west-1.amazonaws.com/maven/repository/")
+      .hasMessageContaining("{domain}-{owner}.d.codeartifact.{region}.amazonaws.com");
+  }
+
+  @Test
+  void testOfWithNonCodeArtifactUrl() {
+    assertThatThrownBy(() -> CodeArtifactUrl.of("https://artifacts.mycompany.com/maven/repository/"))
+      .isInstanceOf(MalformedURLException.class)
+      .hasMessageContaining("Not a valid CodeArtifact repository URL");
+  }
+
+  @Test
+  void testOfWithVpcEndpointUrl() {
+    assertThatThrownBy(() -> CodeArtifactUrl.of(
+      "https://vpce-0743fe535b883ffff-76ddffff.d.codeartifact.us-west-2.vpce.amazonaws.com/maven/d/my-domain-111122223333/my-repo/"))
+      .isInstanceOf(MalformedURLException.class)
+      .hasMessageContaining("Not a valid CodeArtifact repository URL");
+  }
+
+  @Test
+  void testOfWithUppercaseHost() throws MalformedURLException {
+    // when
+    CodeArtifactUrl url = CodeArtifactUrl.of("https://my-domain-111122223333.d.CodeArtifact.us-west-2.amazonaws.com/maven/my-repo/");
+
+    // then
+    assertThat(url.getRegion()).isEqualTo("us-west-2");
+    assertThat(url.getArtifactDomain()).isEqualTo("my-domain");
+    assertThat(url.getArtifactOwner()).isEqualTo("111122223333");
+  }
+
+  @Test
   void testOfWithURLSegments() throws MalformedURLException {
     // Given
     String artifactDomain = "domain";

--- a/src/test/kotlin/ai/clarity/codeartifact/ClarityCodeArtifactGradlePluginTest.kt
+++ b/src/test/kotlin/ai/clarity/codeartifact/ClarityCodeArtifactGradlePluginTest.kt
@@ -115,6 +115,20 @@ class ClarityCodeArtifactGradlePluginTest {
     }
 
     @Test
+    fun `codeartifact extension rejects non-codeartifact urls`() {
+      // Given
+      val project = ProjectBuilder.builder().build()
+      project.plugins.apply("ai.clarity.codeartifact")
+
+      // When/Then
+      assertThatThrownBy { project.repositories.codeartifact("https://artifacts.mycompany.com/maven/repository/") }
+        .isInstanceOf(java.net.MalformedURLException::class.java)
+        .hasMessageContaining("Not a valid CodeArtifact repository URL")
+
+      assertThat(project.repositories).isEmpty()
+    }
+
+    @Test
     fun `codeartifact extension accepts an action`() {
       // Given
       val mockResponse = GetAuthorizationTokenResponse.builder()


### PR DESCRIPTION
## Summary

Follow-up to #781. Three changes:

### fix: validate CodeArtifact repository URLs (`c8aa8fb`)

`CodeArtifactUrl` assumed the `{domain}-{owner}.d.codeartifact.{region}` host structure without validating it, so a malformed URL — a host missing the owner segment, or any non-CodeArtifact URL passed to the explicit `codeartifact()` method — crashed the Gradle configuration phase with a cryptic `StringIndexOutOfBoundsException` / `ArrayIndexOutOfBoundsException` and no hint about which URL was wrong.

The host is now validated (and parsed) with a single pattern, and invalid URLs fail with a `MalformedURLException` carrying the offending URL and the expected format:

```
Not a valid CodeArtifact repository URL: https://artifacts.mycompany.com/maven/repository/
(expected format: https://{domain}-{owner}.d.codeartifact.{region}.amazonaws.com/{format}/{repository}/)
```

Scope decisions, checked against the AWS documentation:
- **Dualstack** hosts (`{domain}-{owner}.d.codeartifact.{region}.on.aws`) are accepted and parsed — rejecting them would have regressed currently-working usage through the explicit `codeartifact()` method.
- **VPC endpoints** (`vpce-*.d.codeartifact.{region}.vpce.amazonaws.com`) are rejected: they carry the domain and owner in the path instead of the host, and were already silently mis-parsed before this change (region resolved to `"vpce"`). Supporting them would be a separate feature.
- Validation is structural (it does not require a 12-digit owner account id), keeping the README examples valid.

New tests: dualstack parsing, host without owner, non-CodeArtifact URL, VPC endpoint, uppercase host, and the Kotlin DSL failing fast without leaving a half-configured repository.

### build: Gradle 10 compatibility (`1ea41dc`)

`val functionalTest by tasks.registering(Test::class)` is deprecated and scheduled for removal in Gradle 10; replaced with `tasks.register<Test>("functionalTest")`. The build now emits no warnings under `--warning-mode all`.

### ci: migrate surefire report action (`23ac243`)

`ScaCap/action-surefire-report@v1` is a legacy release line (support ends 2026-08-01); moved to `ScalableCapital/action-surefire-report@v2.0.4`, which preserves the v1 inputs. Pinned exactly so dependabot keeps bumping it from here. Also widened `report_paths` to `**/build/test-results/**/TEST-*.xml` so the functional test results — which already run in CI — get published in the check too.

## Test plan

- [x] `./gradlew check` — 40 unit tests + 56 functional tests, 0 failures
- [x] `./gradlew help --warning-mode all` — no deprecation warnings
- [x] CI run on this PR exercises the migrated surefire report action

🤖 Generated with [Claude Code](https://claude.com/claude-code)