### PR TITLE
docs: document and test the project default profile pattern with CI/CD override

### DIFF
--- a/README.md
+++ b/README.md
@@ -267,6 +267,35 @@ Or using the command line:
 gradle -Dcodeartifact.profile=<your profile> ...
 ```
 
+### Recommended pattern: project-wide default profile with CI/CD override
+
+To give every developer a default profile without any local setup, while still letting CI/CD
+override it, commit the default to the project's `gradle.properties` instead of using the
+`?profile=` query param:
+
+```properties
+# gradle.properties (committed with the project)
+systemProp.codeartifact.profile=dev
+```
+
+Local builds then use the `dev` profile out of the box, and CI/CD overrides it from the
+command line:
+
+```bash
+gradle -Dcodeartifact.profile=ci ...
+```
+
+Keep in mind:
+
+- The `systemProp.` prefix is required. A plain `codeartifact.profile=dev` entry defines a
+  Gradle project property, which the plugin does not read.
+- Override with `-D` on the command line. The `CODEARTIFACT_PROFILE` environment variable
+  does not take precedence over a system property defined in `gradle.properties`.
+- A developer can override the project default for their machine in
+  `~/.gradle/gradle.properties`, which takes precedence over the project file.
+- Do not combine this pattern with `?profile=` in the repository URL: the query param has
+  the highest precedence and would defeat the override.
+
 ## Profile resolution order
 
 The profile is resolved in the following order of precedence:

--- a/src/functionalTest/kotlin/ai/clarity/codeartifact/ClarityCodeArtifactGradlePluginFunctionalTest.kt
+++ b/src/functionalTest/kotlin/ai/clarity/codeartifact/ClarityCodeArtifactGradlePluginFunctionalTest.kt
@@ -444,6 +444,101 @@ class ClarityCodeartifactPluginFunctionalTest {
   }
 
   @Nested
+  inner class ProfileResolutionFunctionalTest {
+
+    @TempDir
+    lateinit var projectDir: File
+
+    private val buildFile by lazy { File(projectDir, "build.gradle.kts") }
+    private val settingsFile by lazy { File(projectDir, "settings.gradle.kts") }
+    private val gradlePropertiesFile by lazy { File(projectDir, "gradle.properties") }
+
+    @BeforeEach
+    fun setUp() {
+      settingsFile.writeText("""rootProject.name = "test-profile-resolution"""")
+      buildFile.writeText(
+        """
+        plugins {
+            id("ai.clarity.codeartifact")
+        }
+
+        repositories {
+            maven {
+                url = uri("$codeArtifactUrl")
+            }
+        }
+        """.trimIndent()
+      )
+    }
+
+    @ParameterizedTest(name = "Gradle {0}")
+    @MethodSource("ai.clarity.codeartifact.ClarityCodeartifactPluginFunctionalTest#gradleVersions")
+    fun `profile default from gradle properties is used`(gradleVersion: String) {
+      // Given: a project-wide default profile committed in gradle.properties
+      gradlePropertiesFile.writeText("systemProp.codeartifact.profile=dev")
+
+      // When: running the build (expecting a failure due to missing AWS credentials)
+      val result = createRunner(gradleVersion)
+        .withArguments("help", "--info")
+        .buildAndFail()
+
+      // Then: the token fetch uses the project default profile
+      assertThat(result.output).containsIgnoringCase("Getting token for $codeArtifactUrl in profile dev")
+    }
+
+    @ParameterizedTest(name = "Gradle {0}")
+    @MethodSource("ai.clarity.codeartifact.ClarityCodeartifactPluginFunctionalTest#gradleVersions")
+    fun `command line system property overrides the gradle properties default`(gradleVersion: String) {
+      // Given: a project-wide default profile and a CI-style command line override
+      gradlePropertiesFile.writeText("systemProp.codeartifact.profile=dev")
+
+      // When: running the build with -D, as a CI pipeline would
+      val result = createRunner(gradleVersion)
+        .withArguments("help", "--info", "-Dcodeartifact.profile=ci")
+        .buildAndFail()
+
+      // Then: the command line wins over the gradle.properties default
+      assertThat(result.output).containsIgnoringCase("Getting token for $codeArtifactUrl in profile ci")
+    }
+
+    @ParameterizedTest(name = "Gradle {0}")
+    @MethodSource("ai.clarity.codeartifact.ClarityCodeartifactPluginFunctionalTest#gradleVersions")
+    fun `url query param keeps precedence over the gradle properties default`(gradleVersion: String) {
+      // Given: a repository url with an explicit profile and a different project default
+      gradlePropertiesFile.writeText("systemProp.codeartifact.profile=dev")
+      buildFile.writeText(
+        """
+        plugins {
+            id("ai.clarity.codeartifact")
+        }
+
+        repositories {
+            maven {
+                url = uri("$codeArtifactUrl?profile=url-profile")
+            }
+        }
+        """.trimIndent()
+      )
+
+      // When: running the build (expecting a failure due to missing AWS credentials)
+      val result = createRunner(gradleVersion)
+        .withArguments("help", "--info")
+        .buildAndFail()
+
+      // Then: the url query param wins over the gradle.properties default
+      assertThat(result.output).containsIgnoringCase("in profile url-profile")
+    }
+
+    private fun createRunner(gradleVersion: String): GradleRunner {
+      return GradleRunner.create()
+        .withGradleVersion(gradleVersion)
+        .forwardOutput()
+        .withPluginClasspath()
+        .withProjectDir(projectDir)
+    }
+  }
+
+  @Nested
   inner class TokenEndpointFunctionalTest {
 
     @TempDir


### PR DESCRIPTION
## Summary

Addresses the use case in #775 without any behavior change: a project-wide default profile that CI/CD can override is already achievable today — the default just has to live in `gradle.properties` instead of the `?profile=` url query param.

```properties
# gradle.properties (committed with the project)
systemProp.codeartifact.profile=dev
```

```bash
# CI/CD
gradle -Dcodeartifact.profile=ci ...
```

Two commits:

- **`test:`** new `ProfileResolutionFunctionalTest` nested class (3 scenarios × all supported Gradle versions) locking the pattern in: the `gradle.properties` default is picked up, the command-line `-D` overrides it, and the `?profile=` query param keeps its precedence over the project default.
- **`docs:`** new *"Recommended pattern: project-wide default profile with CI/CD override"* subsection under Advanced Usage, including the gotchas that make this pattern easy to get wrong: the `systemProp.` prefix is required (a plain entry is a project property the plugin does not read), the `CODEARTIFACT_PROFILE` env var does not beat a system property, and combining the pattern with `?profile=` in the url would defeat the override.

Every claim in the README section is backed by a functional test, so any future precedence change will surface in the suite.

## Note on #775

This PR documents the existing behavior instead of changing the precedence order or adding configuration API. Intentionally **not** using a closing keyword — the issue can be answered pointing at the new README section and closed once the author confirms it covers their case.

## Test plan

- [x] `./gradlew functionalTest` — 86 tests, 0 failures (15 new)
- [x] Pattern verified manually outside TestKit as well: `systemProp.codeartifact.profile` default is read, command-line `-D` wins

