### PR TITLE
feat: authenticate CodeArtifact with the credentials of a service account

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,8 +91,8 @@ publishing {
 ### Explicit `codeartifact` method
 
 Instead of relying on automatic detection via `maven { url ... }`, you can use the `codeartifact()` helper method
-directly on the `repositories` block. This method accepts the repository URL, an optional profile name, and an optional
-configuration closure/action.
+directly on the `repositories` block. This method accepts the repository URL, an optional profile name or the
+[credentials of a service account](#service-account-credentials), and an optional configuration closure/action.
 
 > **Note:** The `Explicit codeartifact method` can only be used inside the `build.gradle` or `build.gradle.kts` files.
 
@@ -109,8 +109,20 @@ repositories {
     codeartifact("https://domain-id.d.codeartifact.eu-central-1.amazonaws.com/maven/repository/", "prod") {
         name = "myCodeArtifactRepo"
     }
+
+    // With the credentials of a service account instead of a profile:
+    codeartifact(
+        "https://domain-id.d.codeartifact.eu-central-1.amazonaws.com/maven/repository/",
+        CodeArtifactCredentials.of(
+            providers.gradleProperty("codeArtifactAccessKeyId").get(),
+            providers.gradleProperty("codeArtifactSecretAccessKey").get()
+        )
+    )
 }
 ```
+
+> **Note:** in `build.gradle.kts` the helper and the credentials class have to be imported:
+> `import ai.clarity.codeartifact.codeartifact` and `import ai.clarity.codeartifact.CodeArtifactCredentials`.
 
 ### Groovy DSL
 
@@ -125,6 +137,12 @@ repositories {
     codeartifact('https://domain-id.d.codeartifact.eu-central-1.amazonaws.com/maven/repository/', 'prod') {
         name = 'myCodeArtifactRepo'
     }
+
+    // With the credentials of a service account instead of a profile:
+    codeartifact('https://domain-id.d.codeartifact.eu-central-1.amazonaws.com/maven/repository/', [
+            accessKeyId    : providers.gradleProperty('codeArtifactAccessKeyId').get(),
+            secretAccessKey: providers.gradleProperty('codeArtifactSecretAccessKey').get()
+    ])
 }
 ```
 
@@ -296,15 +314,100 @@ Keep in mind:
 - Do not combine this pattern with `?profile=` in the repository URL: the query param has
   the highest precedence and would defeat the override.
 
-## Profile resolution order
+## Service account credentials
 
-The profile is resolved in the following order of precedence:
+On CI/CD, or on any machine without an `~/.aws/credentials` file, the plugin can authenticate with the static access
+keys of a service account — an IAM user or a set of temporary credentials — instead of an AWS profile.
 
-1. `?profile=` query parameter in the repository URL
-2. `codeartifact.profile` Java system property
-3. `CODEARTIFACT_PROFILE` environment variable
-4. `AWS_PROFILE` environment variable (handled by the AWS SDK)
-5. Falls back to `default`
+### For the whole build
+
+Configure the access key id and the secret access key. Each value is read from its system property first, and from its
+environment variable second:
+
+| Value             | System property                | Environment variable             | Required                       |
+|-------------------|--------------------------------|----------------------------------|--------------------------------|
+| Access key id     | `codeartifact.accessKeyId`     | `CODEARTIFACT_ACCESS_KEY_ID`     | Yes                            |
+| Secret access key | `codeartifact.secretAccessKey` | `CODEARTIFACT_SECRET_ACCESS_KEY` | Yes                            |
+| Session token     | `codeartifact.sessionToken`    | `CODEARTIFACT_SESSION_TOKEN`     | Only for temporary credentials |
+
+In a CI/CD pipeline, export them from the secret store of your platform:
+
+```bash
+export CODEARTIFACT_ACCESS_KEY_ID=<your access key id>
+export CODEARTIFACT_SECRET_ACCESS_KEY=<your secret access key>
+```
+
+On a developer machine, declare them in `~/.gradle/gradle.properties`, which lives outside the project:
+
+```properties
+systemProp.codeartifact.accessKeyId=<your access key id>
+systemProp.codeartifact.secretAccessKey=<your secret access key>
+```
+
+They then apply to every CodeArtifact repository of the build, including the ones declared in `settings.gradle(.kts)`,
+and they take precedence over the `codeartifact.profile` / `CODEARTIFACT_PROFILE` configuration.
+
+> **Warning:** never commit these values to the project `gradle.properties`. There is deliberately no `?accessKeyId=`
+> query param either, because the repository URL ends up in build scans, caches and logs. The plugin only writes a
+> masked access key id (`AKIA************MPLE`) to the build log, never the secret.
+
+Setting only one of the two required values fails the build with an explicit message, instead of silently falling back
+to another set of credentials.
+
+### For a single repository
+
+When repositories belong to different AWS accounts, pass the credentials to the `codeartifact()` helper. Read the
+values from Gradle properties or from the environment rather than hardcoding them in the build script.
+
+#### Kotlin DSL
+
+```kotlin
+import ai.clarity.codeartifact.CodeArtifactCredentials
+import ai.clarity.codeartifact.codeartifact
+
+repositories {
+    codeartifact(
+        "https://domain-id.d.codeartifact.eu-central-1.amazonaws.com/maven/repository/",
+        CodeArtifactCredentials.of(
+            providers.gradleProperty("codeArtifactAccessKeyId").get(),
+            providers.gradleProperty("codeArtifactSecretAccessKey").get()
+        )
+    ) {
+        name = "myCodeArtifactRepo"
+    }
+}
+```
+
+#### Groovy DSL
+
+```groovy
+repositories {
+    codeartifact('https://domain-id.d.codeartifact.eu-central-1.amazonaws.com/maven/repository/', [
+            accessKeyId    : providers.gradleProperty('codeArtifactAccessKeyId').get(),
+            secretAccessKey: providers.gradleProperty('codeArtifactSecretAccessKey').get()
+            // add a sessionToken entry only for temporary credentials
+    ]) {
+        name = 'myCodeArtifactRepo'
+    }
+}
+```
+
+> **Note:** as for the profile, the `codeartifact()` helper is not available in `settings.gradle(.kts)`. Use the
+> build-wide configuration above for the repositories declared there.
+
+## Credentials resolution order
+
+The plugin uses the configuration closest to the repository, and prefers service account credentials over profiles at
+the same level:
+
+1. Credentials passed to the `codeartifact()` helper
+2. Profile passed to the `codeartifact()` helper, or `?profile=` query parameter in the repository URL
+3. `codeartifact.accessKeyId` and `codeartifact.secretAccessKey`, each read from the system property first and from the
+   matching `CODEARTIFACT_*` environment variable second
+4. `codeartifact.profile` Java system property
+5. `CODEARTIFACT_PROFILE` environment variable
+6. The AWS SDK default credentials provider chain (`AWS_PROFILE`, `AWS_ACCESS_KEY_ID`, instance roles, …) for the
+   repositories detected automatically, and the `default` profile for the ones declared with the `codeartifact()` helper
 
 ## License
 

--- a/src/functionalTest/kotlin/ai/clarity/codeartifact/ClarityCodeArtifactGradlePluginFunctionalTest.kt
+++ b/src/functionalTest/kotlin/ai/clarity/codeartifact/ClarityCodeArtifactGradlePluginFunctionalTest.kt
@@ -34,6 +34,49 @@ import java.net.InetSocketAddress
 private const val codeArtifactUrl =
   "https://my-domain-111122223333.d.codeartifact.us-west-2.amazonaws.com/maven/my-repo/"
 
+private const val serviceUserAccessKeyId = "AKIAIOSFODNN7EXAMPLE"
+
+// How the plugin is expected to redact the access key id in the build log
+private const val maskedServiceUserAccessKeyId = "AKIA************MPLE"
+
+/**
+ * Stub of the CodeArtifact GetAuthorizationToken endpoint, listening on a random local port.
+ */
+private fun stubCodeArtifactTokenEndpoint(): HttpServer =
+  HttpServer.create(InetSocketAddress("127.0.0.1", 0), 0).apply {
+    createContext("/") { exchange ->
+      val bytes = """{"authorizationToken":"stub-token","expiration":1893456000}""".toByteArray()
+      exchange.responseHeaders.add("Content-Type", "application/json")
+      exchange.sendResponseHeaders(200, bytes.size.toLong())
+      exchange.responseBody.use { it.write(bytes) }
+    }
+    start()
+  }
+
+/**
+ * Build script declaring [repoUrl] as a plain Maven repository, so that the plugin detects it, plus a task printing the
+ * credentials the plugin ended up injecting.
+ */
+private fun printRepoCredentialsBuild(repoUrl: String) = $$"""
+  plugins {
+      id("ai.clarity.codeartifact")
+  }
+
+  repositories {
+      maven {
+          url = uri("$$repoUrl")
+      }
+  }
+
+  tasks.register("printRepoCredentials") {
+      doLast {
+          val repo = project.repositories.first() as org.gradle.api.artifacts.repositories.MavenArtifactRepository
+          println("username=${repo.credentials.username}")
+          println("password=${repo.credentials.password}")
+      }
+  }
+  """.trimIndent()
+
 /**
  * Functional tests for the 'ai.clarity.codeartifact' plugin using Gradle TestKit.
  *
@@ -552,17 +595,7 @@ class ClarityCodeartifactPluginFunctionalTest {
     @BeforeEach
     fun setUp() {
       settingsFile.writeText("""rootProject.name = "test-token-endpoint"""")
-
-      // Stub of the CodeArtifact GetAuthorizationToken endpoint
-      server = HttpServer.create(InetSocketAddress("127.0.0.1", 0), 0)
-      server.createContext("/") { exchange ->
-        val body = """{"authorizationToken":"stub-token","expiration":1893456000}"""
-        val bytes = body.toByteArray()
-        exchange.responseHeaders.add("Content-Type", "application/json")
-        exchange.sendResponseHeaders(200, bytes.size.toLong())
-        exchange.responseBody.use { it.write(bytes) }
-      }
-      server.start()
+      server = stubCodeArtifactTokenEndpoint()
     }
 
     @AfterEach
@@ -573,27 +606,7 @@ class ClarityCodeartifactPluginFunctionalTest {
     @Test
     fun `plugin fetches the token from the codeartifact endpoint and configures credentials`() {
       // Given: a build file relying on automatic detection of the CodeArtifact URL
-      buildFile.writeText(
-        $$"""
-        plugins {
-            id("ai.clarity.codeartifact")
-        }
-
-        repositories {
-            maven {
-                url = uri("$$codeArtifactUrl")
-            }
-        }
-
-        tasks.register("printRepoCredentials") {
-            doLast {
-                val repo = project.repositories.first() as org.gradle.api.artifacts.repositories.MavenArtifactRepository
-                println("username=${repo.credentials.username}")
-                println("password=${repo.credentials.password}")
-            }
-        }
-        """.trimIndent()
-      )
+      buildFile.writeText(printRepoCredentialsBuild(codeArtifactUrl))
 
       // The AWS SDK resolves the service endpoint and static credentials from these variables,
       // so the token request hits the local stub instead of AWS
@@ -619,5 +632,209 @@ class ClarityCodeartifactPluginFunctionalTest {
       assertThat(result.output).contains("password=stub-token")
       assertThat(result.task(":printRepoCredentials")?.outcome).isEqualTo(TaskOutcome.SUCCESS)
     }
+  }
+
+  @Nested
+  inner class ServiceCredentialsFunctionalTest {
+
+    @TempDir
+    lateinit var projectDir: File
+
+    private val buildFile by lazy { File(projectDir, "build.gradle.kts") }
+    private val groovyBuildFile by lazy { File(projectDir, "build.gradle") }
+    private val settingsFile by lazy { File(projectDir, "settings.gradle.kts") }
+    private val gradlePropertiesFile by lazy { File(projectDir, "gradle.properties") }
+
+    private lateinit var server: HttpServer
+
+    @BeforeEach
+    fun setUp() {
+      settingsFile.writeText("""rootProject.name = "test-service-credentials"""")
+      server = stubCodeArtifactTokenEndpoint()
+    }
+
+    @AfterEach
+    fun tearDown() {
+      server.stop(0)
+    }
+
+    @Test
+    fun `service credentials from the environment are used to fetch the token`() {
+      // Given: a repository detected automatically, with no AWS credentials available to the SDK
+      buildFile.writeText(printRepoCredentialsBuild(codeArtifactUrl))
+
+      // When: only the CodeArtifact specific variables carry the service account credentials
+      val result = runnerWithoutAwsCredentials()
+        .withEnvironment(
+          environmentWithoutAwsCredentials(
+            "AWS_ENDPOINT_URL_CODEARTIFACT" to "http://127.0.0.1:${server.address.port}",
+            "CODEARTIFACT_ACCESS_KEY_ID" to serviceUserAccessKeyId,
+            "CODEARTIFACT_SECRET_ACCESS_KEY" to "service-user-secret"
+          )
+        )
+        .withArguments("printRepoCredentials", "--info")
+        .build()
+
+      // Then: the token is fetched with the service credentials and the access key id is masked in the log
+      assertThat(result.output).contains("with the service credentials $maskedServiceUserAccessKeyId")
+      assertThat(result.output).doesNotContain("service-user-secret")
+      assertThat(result.output).contains("username=aws")
+      assertThat(result.output).contains("password=stub-token")
+      assertThat(result.task(":printRepoCredentials")?.outcome).isEqualTo(TaskOutcome.SUCCESS)
+    }
+
+    @Test
+    fun `service credentials from gradle properties are used to fetch the token`() {
+      // Given: the service account credentials declared as system properties of the build
+      buildFile.writeText(printRepoCredentialsBuild(codeArtifactUrl))
+      gradlePropertiesFile.writeText(
+        """
+        systemProp.codeartifact.accessKeyId=$serviceUserAccessKeyId
+        systemProp.codeartifact.secretAccessKey=service-user-secret
+        """.trimIndent()
+      )
+
+      // When: running the build with no AWS credentials in the environment
+      val result = runnerWithoutAwsCredentials()
+        .withEnvironment(
+          environmentWithoutAwsCredentials("AWS_ENDPOINT_URL_CODEARTIFACT" to "http://127.0.0.1:${server.address.port}")
+        )
+        .withArguments("printRepoCredentials", "--info")
+        .build()
+
+      // Then: the repository ends up configured with the token issued for the service account
+      assertThat(result.output).contains("with the service credentials $maskedServiceUserAccessKeyId")
+      assertThat(result.output).contains("password=stub-token")
+    }
+
+    @Test
+    fun `a repository profile keeps precedence over the service credentials of the build`() {
+      // Given: service credentials for the whole build and an explicit profile on the repository
+      buildFile.writeText(printRepoCredentialsBuild("$codeArtifactUrl?profile=url-profile"))
+      gradlePropertiesFile.writeText(
+        """
+        systemProp.codeartifact.accessKeyId=$serviceUserAccessKeyId
+        systemProp.codeartifact.secretAccessKey=service-user-secret
+        """.trimIndent()
+      )
+
+      // When: running the build (expecting a failure because the profile does not exist)
+      val result = runnerWithoutAwsCredentials()
+        .withEnvironment(
+          environmentWithoutAwsCredentials("AWS_ENDPOINT_URL_CODEARTIFACT" to "http://127.0.0.1:${server.address.port}")
+        )
+        .withArguments("printRepoCredentials", "--info")
+        .buildAndFail()
+
+      // Then: the profile named on the repository is the one used
+      assertThat(result.output).containsIgnoringCase("in profile url-profile")
+      assertThat(result.output).doesNotContain("with the service credentials")
+    }
+
+    @Test
+    fun `incomplete service credentials fail with a descriptive error`() {
+      // Given: only half of the service account credentials
+      buildFile.writeText(printRepoCredentialsBuild(codeArtifactUrl))
+      gradlePropertiesFile.writeText("systemProp.codeartifact.accessKeyId=$serviceUserAccessKeyId")
+
+      // When: running the build
+      val result = runnerWithoutAwsCredentials()
+        .withArguments("printRepoCredentials")
+        .buildAndFail()
+
+      // Then: the build explains which half is missing
+      assertThat(result.output).contains("Incomplete CodeArtifact service credentials")
+      assertThat(result.output).contains("codeartifact.secretAccessKey")
+      assertThat(result.output).contains("CODEARTIFACT_SECRET_ACCESS_KEY")
+    }
+
+    @ParameterizedTest(name = "Gradle {0}")
+    @MethodSource("ai.clarity.codeartifact.ClarityCodeartifactPluginFunctionalTest#gradleVersions")
+    fun `kotlin dsl codeartifact method accepts service credentials`(gradleVersion: String) {
+      // Given: a build declaring the credentials on the repository itself
+      buildFile.writeText(
+        """
+        import ai.clarity.codeartifact.CodeArtifactCredentials
+        import ai.clarity.codeartifact.codeartifact
+
+        plugins {
+            id("ai.clarity.codeartifact")
+        }
+
+        repositories {
+            codeartifact(
+                "$codeArtifactUrl",
+                CodeArtifactCredentials.of("$serviceUserAccessKeyId", "service-user-secret")
+            )
+        }
+        """.trimIndent()
+      )
+
+      // When: running the build (expecting a failure because the credentials are not real)
+      val result = GradleRunner.create()
+        .withGradleVersion(gradleVersion)
+        .forwardOutput()
+        .withPluginClasspath()
+        .withProjectDir(projectDir)
+        .withArguments("help", "--info")
+        .buildAndFail()
+
+      // Then: the token request uses the declared credentials and the secret never reaches the log
+      assertThat(result.output).contains("with the service credentials $maskedServiceUserAccessKeyId")
+      assertThat(result.output).doesNotContain("service-user-secret")
+    }
+
+    @ParameterizedTest(name = "Gradle {0}")
+    @MethodSource("ai.clarity.codeartifact.ClarityCodeartifactPluginFunctionalTest#gradleVersions")
+    fun `groovy dsl codeartifact method accepts service credentials as a map`(gradleVersion: String) {
+      // Given: a Groovy build declaring the credentials on the repository itself
+      settingsFile.delete()
+      File(projectDir, "settings.gradle").writeText("rootProject.name = 'test-service-credentials-groovy'")
+      groovyBuildFile.writeText(
+        """
+        plugins {
+            id 'ai.clarity.codeartifact'
+        }
+
+        repositories {
+            codeartifact('$codeArtifactUrl', [
+                accessKeyId    : '$serviceUserAccessKeyId',
+                secretAccessKey: 'service-user-secret'
+            ]) {
+                name = 'serviceUserRepo'
+            }
+        }
+        """.trimIndent()
+      )
+
+      // When: running the build (expecting a failure because the credentials are not real)
+      val result = GradleRunner.create()
+        .withGradleVersion(gradleVersion)
+        .forwardOutput()
+        .withPluginClasspath()
+        .withProjectDir(projectDir)
+        .withArguments("help", "--info")
+        .buildAndFail()
+
+      // Then: the token request uses the declared credentials and the secret never reaches the log
+      assertThat(result.output).contains("with the service credentials $maskedServiceUserAccessKeyId")
+      assertThat(result.output).doesNotContain("service-user-secret")
+    }
+
+    private fun runnerWithoutAwsCredentials(): GradleRunner = GradleRunner.create()
+      .forwardOutput()
+      .withPluginClasspath()
+      .withProjectDir(projectDir)
+
+    private fun environmentWithoutAwsCredentials(vararg entries: Pair<String, String>): Map<String, String> =
+      System.getenv().minus(
+        setOf(
+          "AWS_PROFILE",
+          "CODEARTIFACT_PROFILE",
+          "AWS_ACCESS_KEY_ID",
+          "AWS_SECRET_ACCESS_KEY",
+          "AWS_SESSION_TOKEN"
+        )
+      ) + entries
   }
 }

--- a/src/main/java/ai/clarity/codeartifact/CodeArtifactCredentials.java
+++ b/src/main/java/ai/clarity/codeartifact/CodeArtifactCredentials.java
@@ -1,0 +1,172 @@
+/*
+ * Copyright 2020-2026 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package ai.clarity.codeartifact;
+
+import java.nio.charset.StandardCharsets;
+import java.security.MessageDigest;
+import java.security.NoSuchAlgorithmException;
+import java.util.HexFormat;
+import java.util.LinkedHashSet;
+import java.util.Map;
+import java.util.Objects;
+import java.util.Set;
+import software.amazon.awssdk.auth.credentials.AwsBasicCredentials;
+import software.amazon.awssdk.auth.credentials.AwsCredentials;
+import software.amazon.awssdk.auth.credentials.AwsSessionCredentials;
+
+/**
+ * Static AWS credentials of a service account, used to request the CodeArtifact authorization token without relying on
+ * a local AWS profile.
+ *
+ * <p>A session token can be supplied for temporary credentials, and must be omitted for the long lived access keys of
+ * an IAM user.
+ */
+public final class CodeArtifactCredentials {
+
+  private static final String ACCESS_KEY_ID = "accessKeyId";
+  private static final String SECRET_ACCESS_KEY = "secretAccessKey";
+  private static final String SESSION_TOKEN = "sessionToken";
+
+  private static final Set<String> SUPPORTED_KEYS = Set.of(ACCESS_KEY_ID, SECRET_ACCESS_KEY, SESSION_TOKEN);
+
+  private final String accessKeyId;
+  private final String secretAccessKey;
+  private final String sessionToken;
+
+  private CodeArtifactCredentials(String accessKeyId, String secretAccessKey, String sessionToken) {
+    this.accessKeyId = requireText(accessKeyId, ACCESS_KEY_ID);
+    this.secretAccessKey = requireText(secretAccessKey, SECRET_ACCESS_KEY);
+    this.sessionToken = emptyToNull(sessionToken);
+  }
+
+  public static CodeArtifactCredentials of(String accessKeyId, String secretAccessKey) {
+    return new CodeArtifactCredentials(accessKeyId, secretAccessKey, null);
+  }
+
+  public static CodeArtifactCredentials of(String accessKeyId, String secretAccessKey, String sessionToken) {
+    return new CodeArtifactCredentials(accessKeyId, secretAccessKey, sessionToken);
+  }
+
+  /**
+   * Builds the credentials from a map, which is the shape the Groovy DSL passes them in, as in
+   * {@code codeartifact(url, [accessKeyId: '...', secretAccessKey: '...'])}.
+   */
+  public static CodeArtifactCredentials of(Map<?, ?> values) {
+    Set<String> unsupported = new LinkedHashSet<>();
+    for (Object key : values.keySet()) {
+      String name = String.valueOf(key);
+      if (!SUPPORTED_KEYS.contains(name)) {
+        unsupported.add(name);
+      }
+    }
+    if (!unsupported.isEmpty()) {
+      throw new IllegalArgumentException(
+        "Unsupported CodeArtifact credentials " + unsupported + ", expected any of " + SUPPORTED_KEYS);
+    }
+
+    return new CodeArtifactCredentials(
+      asString(values.get(ACCESS_KEY_ID), ACCESS_KEY_ID),
+      asString(values.get(SECRET_ACCESS_KEY), SECRET_ACCESS_KEY),
+      asString(values.get(SESSION_TOKEN), SESSION_TOKEN));
+  }
+
+  public String getAccessKeyId() {
+    return accessKeyId;
+  }
+
+  /**
+   * The access key id with its middle section hidden, safe to write to the build log.
+   */
+  public String getMaskedAccessKeyId() {
+    if (accessKeyId.length() <= 8) {
+      return "*".repeat(accessKeyId.length());
+    }
+
+    return accessKeyId.substring(0, 4) + "*".repeat(accessKeyId.length() - 8) + accessKeyId.substring(accessKeyId.length() - 4);
+  }
+
+  AwsCredentials toAwsCredentials() {
+    if (sessionToken == null) {
+      return AwsBasicCredentials.create(accessKeyId, secretAccessKey);
+    }
+
+    return AwsSessionCredentials.create(accessKeyId, secretAccessKey, sessionToken);
+  }
+
+  /**
+   * Identifies these credentials in the token cache. It is a digest so that no secret is kept in clear as a cache key.
+   */
+  String cacheKey() {
+    return "credentials:" + digest(accessKeyId + '\0' + secretAccessKey + '\0' + sessionToken);
+  }
+
+  @Override
+  public boolean equals(Object o) {
+    if (this == o) {
+      return true;
+    }
+    if (!(o instanceof CodeArtifactCredentials other)) {
+      return false;
+    }
+
+    return accessKeyId.equals(other.accessKeyId)
+      && secretAccessKey.equals(other.secretAccessKey)
+      && Objects.equals(sessionToken, other.sessionToken);
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(accessKeyId, secretAccessKey, sessionToken);
+  }
+
+  /**
+   * Redacted on purpose: these credentials end up in build logs and in Gradle error messages.
+   */
+  @Override
+  public String toString() {
+    return "CodeArtifactCredentials{accessKeyId=" + getMaskedAccessKeyId()
+      + ", sessionToken=" + (sessionToken == null ? "absent" : "present") + "}";
+  }
+
+  private static String digest(String value) {
+    try {
+      return HexFormat.of().formatHex(MessageDigest.getInstance("SHA-256").digest(value.getBytes(StandardCharsets.UTF_8)));
+    } catch (NoSuchAlgorithmException e) {
+      throw new IllegalStateException("SHA-256 is not available in this JVM", e);
+    }
+  }
+
+  private static String asString(Object value, String name) {
+    if (value == null || value instanceof CharSequence) {
+      return value == null ? null : value.toString();
+    }
+    // The value itself is never part of the message, it may be the secret access key
+    throw new IllegalArgumentException("The CodeArtifact credentials " + name + " must be a String but is a "
+      + value.getClass().getName() + ", call get() on it if it is a Gradle provider");
+  }
+
+  private static String requireText(String value, String name) {
+    if (value == null || value.isBlank()) {
+      throw new IllegalArgumentException("The CodeArtifact credentials " + name + " is required and cannot be blank");
+    }
+
+    return value;
+  }
+
+  private static String emptyToNull(String value) {
+    return value == null || value.isBlank() ? null : value;
+  }
+}

--- a/src/main/java/ai/clarity/codeartifact/CodeArtifactToken.java
+++ b/src/main/java/ai/clarity/codeartifact/CodeArtifactToken.java
@@ -35,7 +35,20 @@ public class CodeArtifactToken implements BuildService<None> {
     CodeArtifactUrl codeArtifactUrl = CodeArtifactUrl.of(uri);
 
     return tokensCache
-      .computeIfAbsent(profile + "@" + uri, k -> TokenFactory.getAuthorizationToken(codeArtifactUrl, profile).authorizationToken());
+      .computeIfAbsent("profile:" + profile + "@" + uri,
+        k -> TokenFactory.getAuthorizationToken(codeArtifactUrl, profile).authorizationToken());
+  }
+
+  public String getToken(URI uri, CodeArtifactCredentials credentials) throws MalformedURLException {
+    return getToken(uri.toString(), credentials);
+  }
+
+  public String getToken(String uri, CodeArtifactCredentials credentials) throws MalformedURLException {
+    CodeArtifactUrl codeArtifactUrl = CodeArtifactUrl.of(uri);
+
+    return tokensCache
+      .computeIfAbsent(credentials.cacheKey() + "@" + uri,
+        k -> TokenFactory.getAuthorizationToken(codeArtifactUrl, credentials).authorizationToken());
   }
 
   @Override

--- a/src/main/java/ai/clarity/codeartifact/TokenFactory.java
+++ b/src/main/java/ai/clarity/codeartifact/TokenFactory.java
@@ -16,7 +16,9 @@
 package ai.clarity.codeartifact;
 
 import java.net.MalformedURLException;
+import software.amazon.awssdk.auth.credentials.AwsCredentialsProvider;
 import software.amazon.awssdk.auth.credentials.ProfileCredentialsProvider;
+import software.amazon.awssdk.auth.credentials.StaticCredentialsProvider;
 import software.amazon.awssdk.regions.Region;
 import software.amazon.awssdk.services.codeartifact.CodeartifactClient;
 import software.amazon.awssdk.services.codeartifact.CodeartifactClientBuilder;
@@ -29,12 +31,29 @@ public class TokenFactory {
     return getAuthorizationToken(CodeArtifactUrl.of(codeArtifactUrl), profileName);
   }
 
+  /**
+   * Requests the token with the given AWS profile, or with the default credentials provider chain when
+   * {@code profileName} is {@code null}.
+   */
   public static GetAuthorizationTokenResponse getAuthorizationToken(CodeArtifactUrl codeArtifactUrl, String profileName) {
+    return requestToken(codeArtifactUrl, profileName == null ? null : ProfileCredentialsProvider.create(profileName));
+  }
+
+  /**
+   * Requests the token with the static credentials of a service account, bypassing the local AWS profiles.
+   */
+  public static GetAuthorizationTokenResponse getAuthorizationToken(CodeArtifactUrl codeArtifactUrl,
+                                                                    CodeArtifactCredentials credentials) {
+    return requestToken(codeArtifactUrl, StaticCredentialsProvider.create(credentials.toAwsCredentials()));
+  }
+
+  private static GetAuthorizationTokenResponse requestToken(CodeArtifactUrl codeArtifactUrl,
+                                                            AwsCredentialsProvider credentialsProvider) {
     CodeartifactClientBuilder builder = CodeartifactClient.builder()
       .region(Region.of(codeArtifactUrl.getRegion()));
 
-    if (profileName != null) {
-      builder = builder.credentialsProvider(ProfileCredentialsProvider.create(profileName));
+    if (credentialsProvider != null) {
+      builder = builder.credentialsProvider(credentialsProvider);
     }
     CodeartifactClient client = builder.build();
 

--- a/src/main/kotlin/ai/clarity/codeartifact/ClarityCodeArtifactGradlePlugin.kt
+++ b/src/main/kotlin/ai/clarity/codeartifact/ClarityCodeArtifactGradlePlugin.kt
@@ -17,6 +17,7 @@
 
 package ai.clarity.codeartifact
 
+import ai.clarity.codeartifact.CodeArtifactAuthenticator.DEFAULT_PROFILE
 import org.gradle.api.Action
 import org.gradle.api.Plugin
 import org.gradle.api.Project
@@ -43,22 +44,45 @@ class ClarityCodeArtifactGradlePlugin : Plugin<Any> {
   }
 }
 
+/**
+ * Declares a CodeArtifact repository authenticated with an AWS profile.
+ *
+ * When [profile] is omitted the repository falls back to the service account credentials configured for the build, and
+ * to the `default` profile when there is none.
+ */
 // Kotlin DSL extension
 @Suppress("unused")
 fun RepositoryHandler.codeartifact(
   repoUrl: String,
-  profile: String = "default",
+  profile: String? = null,
   action: Action<in MavenArtifactRepository>? = null
+) = codeartifactRepository(repoUrl, null, profile, action)
+
+/**
+ * Declares a CodeArtifact repository authenticated with the static credentials of a service account, which take
+ * precedence over any profile configured for the build.
+ */
+@Suppress("unused")
+fun RepositoryHandler.codeartifact(
+  repoUrl: String,
+  credentials: CodeArtifactCredentials,
+  action: Action<in MavenArtifactRepository>? = null
+) = codeartifactRepository(repoUrl, credentials, null, action)
+
+private fun RepositoryHandler.codeartifactRepository(
+  repoUrl: String,
+  credentials: CodeArtifactCredentials?,
+  profile: String?,
+  action: Action<in MavenArtifactRepository>?
 ) {
   val logger = Logging.getLogger(RepositoryHandler::class.java)
-  logger.info("Configuring CodeArtifact repository: url={}, profile={}", repoUrl, profile)
-
   val ext = (this as ExtensionAware).extensions.extraProperties
 
   @Suppress("UNCHECKED_CAST")
   val serviceProvider = ext["codeartifactServiceProvider"] as Provider<CodeArtifactToken>
-  logger.info("Getting token for $repoUrl in profile $profile")
-  val token = serviceProvider.get().getToken(repoUrl, profile)
+  val token = CodeArtifactAuthenticator.getToken(
+    serviceProvider.get(), logger, repoUrl, credentials, profile, DEFAULT_PROFILE
+  )
   maven { mavenRepo ->
     mavenRepo.url = URI(repoUrl)
     mavenRepo.credentials { creds ->

--- a/src/main/kotlin/ai/clarity/codeartifact/CodeArtifactAuthenticator.kt
+++ b/src/main/kotlin/ai/clarity/codeartifact/CodeArtifactAuthenticator.kt
@@ -1,0 +1,57 @@
+/*
+ * Copyright 2020-2026 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+
+package ai.clarity.codeartifact
+
+import org.gradle.api.logging.Logger
+
+/**
+ * Decides how a single repository authenticates against CodeArtifact and returns its authorization token.
+ */
+internal object CodeArtifactAuthenticator {
+
+  const val DEFAULT_PROFILE = "default"
+
+  /**
+   * Resolves the authentication for [repoUrl] and returns the token, giving precedence to the configuration that is
+   * closest to the repository:
+   *
+   *  1. [credentials] declared on the repository itself
+   *  2. [profile] declared on the repository itself
+   *  3. the service account credentials shared by the build ([CodeArtifactCredentialsResolver])
+   *  4. [fallbackProfile], which may be `null` to let the AWS SDK resolve the credentials on its own
+   */
+  fun getToken(
+    tokenService: CodeArtifactToken,
+    logger: Logger,
+    repoUrl: String,
+    credentials: CodeArtifactCredentials? = null,
+    profile: String? = null,
+    fallbackProfile: String? = null
+  ): String {
+    val serviceCredentials = credentials ?: if (profile == null) CodeArtifactCredentialsResolver.resolve() else null
+    if (serviceCredentials != null) {
+      logger.info("Getting token for {} with the service credentials {}", repoUrl, serviceCredentials.maskedAccessKeyId)
+      return tokenService.getToken(repoUrl, serviceCredentials)
+    }
+
+    val resolvedProfile = profile ?: fallbackProfile
+    logger.info("Getting token for {} in profile {}", repoUrl, resolvedProfile)
+
+    return tokenService.getToken(repoUrl, resolvedProfile)
+  }
+}

--- a/src/main/kotlin/ai/clarity/codeartifact/CodeArtifactCredentialsResolver.kt
+++ b/src/main/kotlin/ai/clarity/codeartifact/CodeArtifactCredentialsResolver.kt
@@ -1,0 +1,72 @@
+/*
+ * Copyright 2020-2026 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+
+package ai.clarity.codeartifact
+
+import org.gradle.api.InvalidUserDataException
+
+/**
+ * Resolves the service account credentials shared by the whole build, from system properties first and environment
+ * variables second.
+ *
+ * They are deliberately not read from the repository URL: a query param would leak the secret access key into build
+ * scans, caches and logs.
+ */
+internal object CodeArtifactCredentialsResolver {
+
+  private val ACCESS_KEY_ID = Source("codeartifact.accessKeyId", "CODEARTIFACT_ACCESS_KEY_ID")
+  private val SECRET_ACCESS_KEY = Source("codeartifact.secretAccessKey", "CODEARTIFACT_SECRET_ACCESS_KEY")
+  private val SESSION_TOKEN = Source("codeartifact.sessionToken", "CODEARTIFACT_SESSION_TOKEN")
+
+  /**
+   * Returns the configured credentials, or `null` when none is configured and the profile based authentication has to
+   * be used instead.
+   *
+   * The lookups are parameters so that the tests can exercise the environment variables without mutating the JVM.
+   */
+  fun resolve(
+    systemProperties: (String) -> String? = System::getProperty,
+    environment: (String) -> String? = System::getenv
+  ): CodeArtifactCredentials? {
+    val accessKeyId = ACCESS_KEY_ID.read(systemProperties, environment)
+    val secretAccessKey = SECRET_ACCESS_KEY.read(systemProperties, environment)
+
+    if (accessKeyId == null && secretAccessKey == null) {
+      return null
+    }
+    if (accessKeyId == null) {
+      throw incompleteCredentials(ACCESS_KEY_ID)
+    }
+    if (secretAccessKey == null) {
+      throw incompleteCredentials(SECRET_ACCESS_KEY)
+    }
+
+    return CodeArtifactCredentials.of(accessKeyId, secretAccessKey, SESSION_TOKEN.read(systemProperties, environment))
+  }
+
+  private fun incompleteCredentials(missing: Source) = InvalidUserDataException(
+    "Incomplete CodeArtifact service credentials: neither the ${missing.systemProperty} system property nor the " +
+      "${missing.environmentVariable} environment variable is set. Configure both the access key id and the secret " +
+      "access key, or unset them to authenticate with an AWS profile."
+  )
+
+  private data class Source(val systemProperty: String, val environmentVariable: String) {
+
+    fun read(systemProperties: (String) -> String?, environment: (String) -> String?): String? =
+      (systemProperties(systemProperty) ?: environment(environmentVariable))?.takeIf { it.isNotBlank() }
+  }
+}

--- a/src/main/kotlin/ai/clarity/codeartifact/CodeartifactRepositoryConfigurer.kt
+++ b/src/main/kotlin/ai/clarity/codeartifact/CodeartifactRepositoryConfigurer.kt
@@ -17,6 +17,7 @@
 
 package ai.clarity.codeartifact
 
+import ai.clarity.codeartifact.CodeArtifactAuthenticator.DEFAULT_PROFILE
 import groovy.lang.Closure
 import org.gradle.api.artifacts.dsl.RepositoryHandler
 import org.gradle.api.artifacts.repositories.MavenArtifactRepository
@@ -46,12 +47,41 @@ internal object CodeartifactRepositoryConfigurer {
     ext["codeartifactServiceProvider"] = serviceProvider
 
     if (!ext.has("codeartifact")) {
-      logger.debug("Adding codeartifact(String, String, Closure) method to RepositoryHandler via extraProperties")
+      logger.debug("Adding the codeartifact(url, profile|credentials, Closure) method to RepositoryHandler via extraProperties")
       val closure = object : Closure<Any>(repositories, repositories) {
+
         @Suppress("unused")
-        fun doCall(repoUrl: String, profile: String = "default", closure: Closure<*>? = null) {
-          logger.info("Getting token for $repoUrl in profile $profile")
-          val token = serviceProvider.get().getToken(repoUrl, profile)
+        fun doCall(repoUrl: String) = register(repoUrl, null, null, null)
+
+        @Suppress("unused")
+        fun doCall(repoUrl: String, profile: String) = register(repoUrl, null, profile, null)
+
+        @Suppress("unused")
+        fun doCall(repoUrl: String, profile: String, closure: Closure<*>?) = register(repoUrl, null, profile, closure)
+
+        @Suppress("unused")
+        fun doCall(repoUrl: String, credentials: CodeArtifactCredentials) = register(repoUrl, credentials, null, null)
+
+        @Suppress("unused")
+        fun doCall(repoUrl: String, credentials: CodeArtifactCredentials, closure: Closure<*>?) =
+          register(repoUrl, credentials, null, closure)
+
+        @Suppress("unused")
+        fun doCall(repoUrl: String, credentials: Map<*, *>) = doCall(repoUrl, CodeArtifactCredentials.of(credentials))
+
+        @Suppress("unused")
+        fun doCall(repoUrl: String, credentials: Map<*, *>, closure: Closure<*>?) =
+          doCall(repoUrl, CodeArtifactCredentials.of(credentials), closure)
+
+        private fun register(
+          repoUrl: String,
+          credentials: CodeArtifactCredentials?,
+          profile: String?,
+          closure: Closure<*>?
+        ) {
+          val token = CodeArtifactAuthenticator.getToken(
+            serviceProvider.get(), logger, repoUrl, credentials, profile, DEFAULT_PROFILE
+          )
           val handler = delegate as RepositoryHandler
           handler.maven { mavenRepo ->
             mavenRepo.url = URI(repoUrl)
@@ -66,16 +96,6 @@ internal object CodeartifactRepositoryConfigurer {
             }
           }
         }
-
-        @Suppress("unused")
-        fun doCall(repoUrl: String) {
-          doCall(repoUrl, "default", null)
-        }
-
-        @Suppress("unused")
-        fun doCall(repoUrl: String, profile: String) {
-          doCall(repoUrl, profile, null)
-        }
       }
       ext["codeartifact"] = closure
     }
@@ -89,10 +109,13 @@ internal object CodeartifactRepositoryConfigurer {
     repositories.withType(MavenArtifactRepository::class.java).configureEach { artifactRepository ->
       val repoUri = artifactRepository.url
       if (isCodeArtifactUri(repoUri) && areCredentialsEmpty(artifactRepository)) {
-        val profile = getProfileFromUri(repoUri, getDefaultProfile())
-        logger.info("Getting token for {} in profile {}", repoUri, profile)
-
-        val token = serviceProvider.get().getToken(repoUri, profile)
+        val token = CodeArtifactAuthenticator.getToken(
+          serviceProvider.get(),
+          logger,
+          repoUri.toString(),
+          profile = getProfileFromUri(repoUri),
+          fallbackProfile = getDefaultProfile()
+        )
         artifactRepository.credentials { creds ->
           creds.username = "aws"
           creds.password = token
@@ -118,7 +141,7 @@ internal object CodeartifactRepositoryConfigurer {
     return uri.toString().matches("(?i).+\\.codeartifact\\..+\\.amazonaws\\..+".toRegex())
   }
 
-  private fun getProfileFromUri(uri: URI, defaultValue: String?): String? {
-    return URIBuilder.of(uri).getQueryParamValue("profile") ?: defaultValue
+  private fun getProfileFromUri(uri: URI): String? {
+    return URIBuilder.of(uri).getQueryParamValue("profile")
   }
 }

--- a/src/test/kotlin/ai/clarity/codeartifact/ClarityCodeArtifactGradlePluginTest.kt
+++ b/src/test/kotlin/ai/clarity/codeartifact/ClarityCodeArtifactGradlePluginTest.kt
@@ -58,6 +58,8 @@ class ClarityCodeArtifactGradlePluginTest {
     @AfterEach
     fun tearDown() {
       unmockkAll()
+      System.clearProperty("codeartifact.accessKeyId")
+      System.clearProperty("codeartifact.secretAccessKey")
     }
 
     @Test
@@ -115,6 +117,90 @@ class ClarityCodeArtifactGradlePluginTest {
     }
 
     @Test
+    fun `codeartifact extension configures repository with service credentials`() {
+      // Given
+      val credentials = CodeArtifactCredentials.of("AKIAIOSFODNN7EXAMPLE", "service-user-secret")
+      val mockResponse = GetAuthorizationTokenResponse.builder()
+        .authorizationToken("mock-token-service-user")
+        .build()
+
+      mockkStatic(TokenFactory::class)
+      every { TokenFactory.getAuthorizationToken(any<CodeArtifactUrl>(), credentials) } returns mockResponse
+
+      val project = ProjectBuilder.builder().build()
+      project.plugins.apply("ai.clarity.codeartifact")
+
+      val codeArtifactUrl = "https://my-domain-111122223333.d.codeartifact.us-west-2.amazonaws.com/maven/my-repo/"
+
+      // When
+      project.repositories.codeartifact(codeArtifactUrl, credentials) {
+        it.name = "serviceUserRepo"
+      }
+
+      // Then
+      val repository = project.repositories.first() as MavenArtifactRepository
+      assertThat(repository.name).isEqualTo("serviceUserRepo")
+      assertThat(repository.url).isEqualTo(URI(codeArtifactUrl))
+      assertThat(repository.credentials.username).isEqualTo("aws")
+      assertThat(repository.credentials.password).isEqualTo("mock-token-service-user")
+
+      verify(exactly = 1) { TokenFactory.getAuthorizationToken(any<CodeArtifactUrl>(), credentials) }
+      verify(exactly = 0) { TokenFactory.getAuthorizationToken(any<CodeArtifactUrl>(), any<String>()) }
+    }
+
+    @Test
+    fun `codeartifact extension without a profile uses the service credentials of the build`() {
+      // Given
+      System.setProperty("codeartifact.accessKeyId", "AKIAIOSFODNN7EXAMPLE")
+      System.setProperty("codeartifact.secretAccessKey", "service-user-secret")
+
+      val credentials = CodeArtifactCredentials.of("AKIAIOSFODNN7EXAMPLE", "service-user-secret")
+
+      mockkStatic(TokenFactory::class)
+      every { TokenFactory.getAuthorizationToken(any<CodeArtifactUrl>(), credentials) } returns
+        GetAuthorizationTokenResponse.builder().authorizationToken("mock-token-service-user").build()
+
+      val project = ProjectBuilder.builder().build()
+      project.plugins.apply("ai.clarity.codeartifact")
+
+      val codeArtifactUrl = "https://my-domain-111122223333.d.codeartifact.us-west-2.amazonaws.com/maven/my-repo/"
+
+      // When
+      project.repositories.codeartifact(codeArtifactUrl)
+
+      // Then
+      val repository = project.repositories.first() as MavenArtifactRepository
+      assertThat(repository.credentials.password).isEqualTo("mock-token-service-user")
+
+      verify(exactly = 0) { TokenFactory.getAuthorizationToken(any<CodeArtifactUrl>(), any<String>()) }
+    }
+
+    @Test
+    fun `an explicit profile takes precedence over the service credentials of the build`() {
+      // Given
+      System.setProperty("codeartifact.accessKeyId", "AKIAIOSFODNN7EXAMPLE")
+      System.setProperty("codeartifact.secretAccessKey", "service-user-secret")
+
+      mockkStatic(TokenFactory::class)
+      every { TokenFactory.getAuthorizationToken(any<CodeArtifactUrl>(), "my-profile") } returns
+        GetAuthorizationTokenResponse.builder().authorizationToken("mock-token-profile").build()
+
+      val project = ProjectBuilder.builder().build()
+      project.plugins.apply("ai.clarity.codeartifact")
+
+      val codeArtifactUrl = "https://my-domain-111122223333.d.codeartifact.us-west-2.amazonaws.com/maven/my-repo/"
+
+      // When
+      project.repositories.codeartifact(codeArtifactUrl, "my-profile")
+
+      // Then
+      val repository = project.repositories.first() as MavenArtifactRepository
+      assertThat(repository.credentials.password).isEqualTo("mock-token-profile")
+
+      verify(exactly = 0) { TokenFactory.getAuthorizationToken(any<CodeArtifactUrl>(), any<CodeArtifactCredentials>()) }
+    }
+
+    @Test
     fun `codeartifact extension rejects non-codeartifact urls`() {
       // Given
       val project = ProjectBuilder.builder().build()
@@ -136,7 +222,7 @@ class ClarityCodeArtifactGradlePluginTest {
         .build()
 
       mockkStatic(TokenFactory::class)
-      every { TokenFactory.getAuthorizationToken(any<CodeArtifactUrl>(), any()) } returns mockResponse
+      every { TokenFactory.getAuthorizationToken(any<CodeArtifactUrl>(), any<String>()) } returns mockResponse
 
       val project = ProjectBuilder.builder().build()
       project.plugins.apply("ai.clarity.codeartifact")

--- a/src/test/kotlin/ai/clarity/codeartifact/CodeArtifactCredentialsResolverTest.kt
+++ b/src/test/kotlin/ai/clarity/codeartifact/CodeArtifactCredentialsResolverTest.kt
@@ -1,0 +1,115 @@
+/*
+ * Copyright 2020-2026 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+
+package ai.clarity.codeartifact
+
+import org.assertj.core.api.Assertions.assertThat
+import org.assertj.core.api.Assertions.assertThatThrownBy
+import org.gradle.api.InvalidUserDataException
+import org.junit.jupiter.api.Test
+
+class CodeArtifactCredentialsResolverTest {
+
+  private fun resolve(systemProperties: Map<String, String> = emptyMap(), environment: Map<String, String> = emptyMap()) =
+    CodeArtifactCredentialsResolver.resolve(systemProperties::get, environment::get)
+
+  @Test
+  fun `no credentials are resolved when nothing is configured`() {
+    assertThat(resolve()).isNull()
+  }
+
+  @Test
+  fun `credentials are resolved from the system properties`() {
+    // When
+    val credentials = resolve(
+      systemProperties = mapOf(
+        "codeartifact.accessKeyId" to "sysprop-key-id",
+        "codeartifact.secretAccessKey" to "sysprop-secret"
+      )
+    )
+
+    // Then
+    assertThat(credentials).isEqualTo(CodeArtifactCredentials.of("sysprop-key-id", "sysprop-secret"))
+  }
+
+  @Test
+  fun `credentials are resolved from the environment variables`() {
+    // When
+    val credentials = resolve(
+      environment = mapOf(
+        "CODEARTIFACT_ACCESS_KEY_ID" to "env-key-id",
+        "CODEARTIFACT_SECRET_ACCESS_KEY" to "env-secret",
+        "CODEARTIFACT_SESSION_TOKEN" to "env-session-token"
+      )
+    )
+
+    // Then
+    assertThat(credentials).isEqualTo(CodeArtifactCredentials.of("env-key-id", "env-secret", "env-session-token"))
+  }
+
+  @Test
+  fun `each system property takes precedence over its environment variable`() {
+    // When
+    val credentials = resolve(
+      systemProperties = mapOf("codeartifact.accessKeyId" to "sysprop-key-id"),
+      environment = mapOf(
+        "CODEARTIFACT_ACCESS_KEY_ID" to "env-key-id",
+        "CODEARTIFACT_SECRET_ACCESS_KEY" to "env-secret"
+      )
+    )
+
+    // Then
+    assertThat(credentials).isEqualTo(CodeArtifactCredentials.of("sysprop-key-id", "env-secret"))
+  }
+
+  @Test
+  fun `the session token is optional`() {
+    // When
+    val credentials = resolve(
+      systemProperties = mapOf(
+        "codeartifact.accessKeyId" to "key-id",
+        "codeartifact.secretAccessKey" to "secret"
+      )
+    )
+
+    // Then
+    assertThat(credentials).isEqualTo(CodeArtifactCredentials.of("key-id", "secret"))
+  }
+
+  @Test
+  fun `blank values are ignored`() {
+    assertThat(
+      resolve(systemProperties = mapOf("codeartifact.accessKeyId" to "  ", "codeartifact.secretAccessKey" to "  "))
+    ).isNull()
+  }
+
+  @Test
+  fun `a secret access key without an access key id is rejected`() {
+    assertThatThrownBy { resolve(systemProperties = mapOf("codeartifact.secretAccessKey" to "secret")) }
+      .isInstanceOf(InvalidUserDataException::class.java)
+      .hasMessageContaining("codeartifact.accessKeyId")
+      .hasMessageContaining("CODEARTIFACT_ACCESS_KEY_ID")
+  }
+
+  @Test
+  fun `an access key id without a secret access key is rejected`() {
+    assertThatThrownBy { resolve(environment = mapOf("CODEARTIFACT_ACCESS_KEY_ID" to "key-id")) }
+      .isInstanceOf(InvalidUserDataException::class.java)
+      .hasMessageContaining("codeartifact.secretAccessKey")
+      .hasMessageContaining("CODEARTIFACT_SECRET_ACCESS_KEY")
+  }
+}

--- a/src/test/kotlin/ai/clarity/codeartifact/CodeArtifactCredentialsTest.kt
+++ b/src/test/kotlin/ai/clarity/codeartifact/CodeArtifactCredentialsTest.kt
@@ -1,0 +1,224 @@
+/*
+ * Copyright 2020-2026 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+
+package ai.clarity.codeartifact
+
+import org.assertj.core.api.Assertions.assertThat
+import org.assertj.core.api.Assertions.assertThatThrownBy
+import org.junit.jupiter.api.Nested
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.params.ParameterizedTest
+import org.junit.jupiter.params.provider.ValueSource
+import software.amazon.awssdk.auth.credentials.AwsSessionCredentials
+
+private const val ACCESS_KEY_ID = "AKIAIOSFODNN7EXAMPLE"
+private const val SECRET_ACCESS_KEY = "wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY"
+
+class CodeArtifactCredentialsTest {
+
+  @Nested
+  inner class CreationTest {
+
+    @Test
+    fun `credentials without session token map to basic aws credentials`() {
+      // When
+      val credentials = CodeArtifactCredentials.of(ACCESS_KEY_ID, SECRET_ACCESS_KEY)
+
+      // Then
+      val awsCredentials = credentials.toAwsCredentials()
+      assertThat(credentials.accessKeyId).isEqualTo(ACCESS_KEY_ID)
+      assertThat(awsCredentials.accessKeyId()).isEqualTo(ACCESS_KEY_ID)
+      assertThat(awsCredentials.secretAccessKey()).isEqualTo(SECRET_ACCESS_KEY)
+      assertThat(awsCredentials).isNotInstanceOf(AwsSessionCredentials::class.java)
+    }
+
+    @Test
+    fun `credentials with session token map to temporary aws credentials`() {
+      // When
+      val credentials = CodeArtifactCredentials.of(ACCESS_KEY_ID, SECRET_ACCESS_KEY, "session-token")
+
+      // Then
+      val awsCredentials = credentials.toAwsCredentials()
+      assertThat(awsCredentials).isInstanceOf(AwsSessionCredentials::class.java)
+      assertThat((awsCredentials as AwsSessionCredentials).sessionToken()).isEqualTo("session-token")
+    }
+
+    @Test
+    fun `a blank session token is treated as absent`() {
+      // When
+      val credentials = CodeArtifactCredentials.of(ACCESS_KEY_ID, SECRET_ACCESS_KEY, "  ")
+
+      // Then
+      assertThat(credentials.toAwsCredentials()).isNotInstanceOf(AwsSessionCredentials::class.java)
+      assertThat(credentials).isEqualTo(CodeArtifactCredentials.of(ACCESS_KEY_ID, SECRET_ACCESS_KEY))
+    }
+
+    @ParameterizedTest
+    @ValueSource(strings = ["", "   "])
+    fun `a missing access key id is rejected`(accessKeyId: String) {
+      assertThatThrownBy { CodeArtifactCredentials.of(accessKeyId, SECRET_ACCESS_KEY) }
+        .isInstanceOf(IllegalArgumentException::class.java)
+        .hasMessageContaining("accessKeyId")
+    }
+
+    @ParameterizedTest
+    @ValueSource(strings = ["", "   "])
+    fun `a missing secret access key is rejected`(secretAccessKey: String) {
+      assertThatThrownBy { CodeArtifactCredentials.of(ACCESS_KEY_ID, secretAccessKey) }
+        .isInstanceOf(IllegalArgumentException::class.java)
+        .hasMessageContaining("secretAccessKey")
+    }
+  }
+
+  @Nested
+  inner class MapCreationTest {
+
+    @Test
+    fun `credentials are built from a map`() {
+      // When
+      val credentials = CodeArtifactCredentials.of(
+        mapOf(
+          "accessKeyId" to ACCESS_KEY_ID,
+          "secretAccessKey" to SECRET_ACCESS_KEY,
+          "sessionToken" to "session-token"
+        )
+      )
+
+      // Then
+      assertThat(credentials).isEqualTo(CodeArtifactCredentials.of(ACCESS_KEY_ID, SECRET_ACCESS_KEY, "session-token"))
+    }
+
+    @Test
+    fun `the session token entry is optional`() {
+      // When
+      val credentials = CodeArtifactCredentials.of(
+        mapOf("accessKeyId" to ACCESS_KEY_ID, "secretAccessKey" to SECRET_ACCESS_KEY)
+      )
+
+      // Then
+      assertThat(credentials).isEqualTo(CodeArtifactCredentials.of(ACCESS_KEY_ID, SECRET_ACCESS_KEY))
+    }
+
+    @Test
+    fun `an unsupported entry is rejected`() {
+      assertThatThrownBy {
+        CodeArtifactCredentials.of(
+          mapOf("accessKeyId" to ACCESS_KEY_ID, "secretAccessKey" to SECRET_ACCESS_KEY, "profile" to "prod")
+        )
+      }
+        .isInstanceOf(IllegalArgumentException::class.java)
+        .hasMessageContaining("profile")
+    }
+
+    @Test
+    fun `any char sequence is accepted, as Groovy passes GStrings`() {
+      // When
+      val credentials = CodeArtifactCredentials.of(
+        mapOf("accessKeyId" to StringBuilder(ACCESS_KEY_ID), "secretAccessKey" to StringBuilder(SECRET_ACCESS_KEY))
+      )
+
+      // Then
+      assertThat(credentials).isEqualTo(CodeArtifactCredentials.of(ACCESS_KEY_ID, SECRET_ACCESS_KEY))
+    }
+
+    @Test
+    fun `a value that is not a char sequence is rejected without disclosing it`() {
+      assertThatThrownBy {
+        CodeArtifactCredentials.of(mapOf("accessKeyId" to ACCESS_KEY_ID, "secretAccessKey" to 1234))
+      }
+        .isInstanceOf(IllegalArgumentException::class.java)
+        .hasMessageContaining("secretAccessKey")
+        .hasMessageContaining("java.lang.Integer")
+        .hasMessageNotContaining("1234")
+    }
+
+    @Test
+    fun `a map without the secret access key is rejected`() {
+      assertThatThrownBy { CodeArtifactCredentials.of(mapOf("accessKeyId" to ACCESS_KEY_ID)) }
+        .isInstanceOf(IllegalArgumentException::class.java)
+        .hasMessageContaining("secretAccessKey")
+    }
+  }
+
+  @Nested
+  inner class RedactionTest {
+
+    @Test
+    fun `the masked access key id keeps only its edges`() {
+      assertThat(CodeArtifactCredentials.of(ACCESS_KEY_ID, SECRET_ACCESS_KEY).maskedAccessKeyId)
+        .isEqualTo("AKIA************MPLE")
+    }
+
+    @Test
+    fun `a short access key id is masked entirely`() {
+      assertThat(CodeArtifactCredentials.of("AKIA1234", SECRET_ACCESS_KEY).maskedAccessKeyId).isEqualTo("********")
+    }
+
+    @Test
+    fun `toString never exposes the secrets`() {
+      // When
+      val description = CodeArtifactCredentials.of(ACCESS_KEY_ID, SECRET_ACCESS_KEY, "session-token").toString()
+
+      // Then
+      assertThat(description).doesNotContain(SECRET_ACCESS_KEY, "session-token", ACCESS_KEY_ID)
+      assertThat(description).contains("AKIA************MPLE", "sessionToken=present")
+    }
+  }
+
+  @Nested
+  inner class CacheKeyTest {
+
+    @Test
+    fun `equal credentials share the cache key`() {
+      assertThat(CodeArtifactCredentials.of(ACCESS_KEY_ID, SECRET_ACCESS_KEY).cacheKey())
+        .isEqualTo(CodeArtifactCredentials.of(ACCESS_KEY_ID, SECRET_ACCESS_KEY).cacheKey())
+    }
+
+    @Test
+    fun `the cache key never contains the secrets`() {
+      // When
+      val cacheKey = CodeArtifactCredentials.of(ACCESS_KEY_ID, SECRET_ACCESS_KEY, "session-token").cacheKey()
+
+      // Then
+      assertThat(cacheKey).doesNotContain(SECRET_ACCESS_KEY, "session-token", ACCESS_KEY_ID)
+    }
+
+    @Test
+    fun `credentials differing only by the secret do not share the cache key`() {
+      assertThat(CodeArtifactCredentials.of(ACCESS_KEY_ID, SECRET_ACCESS_KEY).cacheKey())
+        .isNotEqualTo(CodeArtifactCredentials.of(ACCESS_KEY_ID, "another-secret").cacheKey())
+    }
+
+    @Test
+    fun `credentials differing only by the session token do not share the cache key`() {
+      assertThat(CodeArtifactCredentials.of(ACCESS_KEY_ID, SECRET_ACCESS_KEY).cacheKey())
+        .isNotEqualTo(CodeArtifactCredentials.of(ACCESS_KEY_ID, SECRET_ACCESS_KEY, "session-token").cacheKey())
+    }
+  }
+
+  @Nested
+  inner class EqualityTest {
+
+    @Test
+    fun `credentials are compared by value`() {
+      assertThat(CodeArtifactCredentials.of(ACCESS_KEY_ID, SECRET_ACCESS_KEY))
+        .isEqualTo(CodeArtifactCredentials.of(ACCESS_KEY_ID, SECRET_ACCESS_KEY))
+        .hasSameHashCodeAs(CodeArtifactCredentials.of(ACCESS_KEY_ID, SECRET_ACCESS_KEY))
+        .isNotEqualTo(CodeArtifactCredentials.of("AKIAANOTHEREXAMPLE00", SECRET_ACCESS_KEY))
+    }
+  }
+}

--- a/src/test/kotlin/ai/clarity/codeartifact/CodeArtifactProjectPluginTest.kt
+++ b/src/test/kotlin/ai/clarity/codeartifact/CodeArtifactProjectPluginTest.kt
@@ -5,6 +5,8 @@ import io.mockk.mockkStatic
 import io.mockk.unmockkAll
 import io.mockk.verify
 import org.assertj.core.api.Assertions.assertThat
+import org.assertj.core.api.Assertions.assertThatThrownBy
+import org.gradle.api.InvalidUserDataException
 import org.gradle.api.artifacts.repositories.MavenArtifactRepository
 import org.gradle.api.publish.PublishingExtension
 import org.gradle.testfixtures.ProjectBuilder
@@ -20,6 +22,9 @@ class CodeArtifactProjectPluginTest {
   fun tearDown() {
     unmockkAll()
     System.clearProperty("codeartifact.profile")
+    System.clearProperty("codeartifact.accessKeyId")
+    System.clearProperty("codeartifact.secretAccessKey")
+    System.clearProperty("codeartifact.sessionToken")
   }
 
   @Test
@@ -30,7 +35,7 @@ class CodeArtifactProjectPluginTest {
       .build()
 
     mockkStatic(TokenFactory::class)
-    every { TokenFactory.getAuthorizationToken(any<CodeArtifactUrl>(), any()) } returns mockResponse
+    every { TokenFactory.getAuthorizationToken(any<CodeArtifactUrl>(), any<String>()) } returns mockResponse
 
     val project = ProjectBuilder.builder().build()
     project.plugins.apply("ai.clarity.codeartifact")
@@ -47,7 +52,7 @@ class CodeArtifactProjectPluginTest {
     assertThat(repository.credentials.username).isEqualTo("aws")
     assertThat(repository.credentials.password).isEqualTo("mock-token")
 
-    verify(exactly = 1) { TokenFactory.getAuthorizationToken(any<CodeArtifactUrl>(), any()) }
+    verify(exactly = 1) { TokenFactory.getAuthorizationToken(any<CodeArtifactUrl>(), any<String>()) }
   }
 
   @Test
@@ -165,7 +170,7 @@ class CodeArtifactProjectPluginTest {
       .build()
 
     mockkStatic(TokenFactory::class)
-    every { TokenFactory.getAuthorizationToken(any<CodeArtifactUrl>(), any()) } returns mockResponse
+    every { TokenFactory.getAuthorizationToken(any<CodeArtifactUrl>(), any<String>()) } returns mockResponse
 
     val project = ProjectBuilder.builder().build()
     project.plugins.apply("ai.clarity.codeartifact")
@@ -184,7 +189,7 @@ class CodeArtifactProjectPluginTest {
     assertThat(repository.credentials.username).isEqualTo("aws")
     assertThat(repository.credentials.password).isEqualTo("mock-token-publish")
 
-    verify(exactly = 1) { TokenFactory.getAuthorizationToken(any<CodeArtifactUrl>(), any()) }
+    verify(exactly = 1) { TokenFactory.getAuthorizationToken(any<CodeArtifactUrl>(), any<String>()) }
   }
 
   @Test
@@ -211,7 +216,7 @@ class CodeArtifactProjectPluginTest {
     assertThat(repository.credentials.username).isEqualTo("existing-user")
     assertThat(repository.credentials.password).isEqualTo("existing-pass")
 
-    verify(exactly = 0) { TokenFactory.getAuthorizationToken(any<CodeArtifactUrl>(), any()) }
+    verify(exactly = 0) { TokenFactory.getAuthorizationToken(any<CodeArtifactUrl>(), any<String>()) }
   }
 
   @Test
@@ -222,7 +227,7 @@ class CodeArtifactProjectPluginTest {
       .build()
 
     mockkStatic(TokenFactory::class)
-    every { TokenFactory.getAuthorizationToken(any<CodeArtifactUrl>(), any()) } returns mockResponse
+    every { TokenFactory.getAuthorizationToken(any<CodeArtifactUrl>(), any<String>()) } returns mockResponse
 
     val project = ProjectBuilder.builder().build()
     project.plugins.apply("ai.clarity.codeartifact")
@@ -240,4 +245,168 @@ class CodeArtifactProjectPluginTest {
     assertThat(repository.credentials.password).isEqualTo("mock-token-case")
   }
 
+  @Test
+  fun `plugin uses the service credentials from the system properties`() {
+    // Given
+    System.setProperty("codeartifact.accessKeyId", "AKIAIOSFODNN7EXAMPLE")
+    System.setProperty("codeartifact.secretAccessKey", "service-user-secret")
+
+    val credentials = CodeArtifactCredentials.of("AKIAIOSFODNN7EXAMPLE", "service-user-secret")
+    val mockResponse = GetAuthorizationTokenResponse.builder()
+      .authorizationToken("mock-token-service-user")
+      .build()
+
+    mockkStatic(TokenFactory::class)
+    every { TokenFactory.getAuthorizationToken(any<CodeArtifactUrl>(), credentials) } returns mockResponse
+
+    val project = ProjectBuilder.builder().build()
+    project.plugins.apply("ai.clarity.codeartifact")
+
+    val codeArtifactUrl = "https://my-domain-111122223333.d.codeartifact.us-west-2.amazonaws.com/maven/my-repo/"
+
+    // When
+    project.repositories.maven { repo ->
+      repo.url = URI(codeArtifactUrl)
+    }
+    val repository = project.repositories.first() as MavenArtifactRepository
+
+    // Then
+    assertThat(repository.credentials.username).isEqualTo("aws")
+    assertThat(repository.credentials.password).isEqualTo("mock-token-service-user")
+
+    verify(exactly = 1) { TokenFactory.getAuthorizationToken(any<CodeArtifactUrl>(), credentials) }
+    verify(exactly = 0) { TokenFactory.getAuthorizationToken(any<CodeArtifactUrl>(), any<String>()) }
+  }
+
+  @Test
+  fun `service credentials carry the session token when configured`() {
+    // Given
+    System.setProperty("codeartifact.accessKeyId", "AKIAIOSFODNN7EXAMPLE")
+    System.setProperty("codeartifact.secretAccessKey", "service-user-secret")
+    System.setProperty("codeartifact.sessionToken", "service-user-session-token")
+
+    val credentials =
+      CodeArtifactCredentials.of("AKIAIOSFODNN7EXAMPLE", "service-user-secret", "service-user-session-token")
+
+    mockkStatic(TokenFactory::class)
+    every { TokenFactory.getAuthorizationToken(any<CodeArtifactUrl>(), credentials) } returns
+      GetAuthorizationTokenResponse.builder().authorizationToken("mock-token-temporary").build()
+
+    val project = ProjectBuilder.builder().build()
+    project.plugins.apply("ai.clarity.codeartifact")
+
+    val codeArtifactUrl = "https://my-domain-111122223333.d.codeartifact.us-west-2.amazonaws.com/maven/my-repo/"
+
+    // When
+    project.repositories.maven { repo ->
+      repo.url = URI(codeArtifactUrl)
+    }
+    val repository = project.repositories.first() as MavenArtifactRepository
+
+    // Then
+    assertThat(repository.credentials.password).isEqualTo("mock-token-temporary")
+    verify(exactly = 1) { TokenFactory.getAuthorizationToken(any<CodeArtifactUrl>(), credentials) }
+  }
+
+  @Test
+  fun `service credentials take precedence over the profile system property`() {
+    // Given
+    System.setProperty("codeartifact.profile", "sysprop-profile")
+    System.setProperty("codeartifact.accessKeyId", "AKIAIOSFODNN7EXAMPLE")
+    System.setProperty("codeartifact.secretAccessKey", "service-user-secret")
+
+    mockkStatic(TokenFactory::class)
+    every { TokenFactory.getAuthorizationToken(any<CodeArtifactUrl>(), any<CodeArtifactCredentials>()) } returns
+      GetAuthorizationTokenResponse.builder().authorizationToken("mock-token-service-user").build()
+
+    val project = ProjectBuilder.builder().build()
+    project.plugins.apply("ai.clarity.codeartifact")
+
+    val codeArtifactUrl = "https://my-domain-111122223333.d.codeartifact.us-west-2.amazonaws.com/maven/my-repo/"
+
+    // When
+    project.repositories.maven { repo ->
+      repo.url = URI(codeArtifactUrl)
+    }
+    val repository = project.repositories.first() as MavenArtifactRepository
+
+    // Then
+    assertThat(repository.credentials.password).isEqualTo("mock-token-service-user")
+    verify(exactly = 0) { TokenFactory.getAuthorizationToken(any<CodeArtifactUrl>(), "sysprop-profile") }
+  }
+
+  @Test
+  fun `profile from url query param has precedence over the service credentials`() {
+    // Given
+    System.setProperty("codeartifact.accessKeyId", "AKIAIOSFODNN7EXAMPLE")
+    System.setProperty("codeartifact.secretAccessKey", "service-user-secret")
+
+    mockkStatic(TokenFactory::class)
+    every { TokenFactory.getAuthorizationToken(any<CodeArtifactUrl>(), "url-profile") } returns
+      GetAuthorizationTokenResponse.builder().authorizationToken("mock-token-url").build()
+
+    val project = ProjectBuilder.builder().build()
+    project.plugins.apply("ai.clarity.codeartifact")
+
+    val codeArtifactUrl = "https://my-domain-111122223333.d.codeartifact.us-west-2.amazonaws.com/maven/my-repo/"
+
+    // When
+    project.repositories.maven { repo ->
+      repo.url = URI("$codeArtifactUrl?profile=url-profile")
+    }
+    val repository = project.repositories.first() as MavenArtifactRepository
+
+    // Then
+    assertThat(repository.credentials.password).isEqualTo("mock-token-url")
+    verify(exactly = 1) { TokenFactory.getAuthorizationToken(any<CodeArtifactUrl>(), "url-profile") }
+    verify(exactly = 0) { TokenFactory.getAuthorizationToken(any<CodeArtifactUrl>(), any<CodeArtifactCredentials>()) }
+  }
+
+  @Test
+  fun `plugin configures publishing repositories with the service credentials`() {
+    // Given
+    System.setProperty("codeartifact.accessKeyId", "AKIAIOSFODNN7EXAMPLE")
+    System.setProperty("codeartifact.secretAccessKey", "service-user-secret")
+
+    mockkStatic(TokenFactory::class)
+    every { TokenFactory.getAuthorizationToken(any<CodeArtifactUrl>(), any<CodeArtifactCredentials>()) } returns
+      GetAuthorizationTokenResponse.builder().authorizationToken("mock-token-publish").build()
+
+    val project = ProjectBuilder.builder().build()
+    project.plugins.apply("ai.clarity.codeartifact")
+    project.plugins.apply("maven-publish")
+
+    val codeArtifactUrl = "https://my-domain-111122223333.d.codeartifact.us-west-2.amazonaws.com/maven/my-repo/"
+
+    // When
+    val publishing = project.extensions.getByType(PublishingExtension::class.java)
+    publishing.repositories.maven { repo ->
+      repo.url = URI(codeArtifactUrl)
+    }
+    val repository = publishing.repositories.first() as MavenArtifactRepository
+
+    // Then
+    assertThat(repository.credentials.username).isEqualTo("aws")
+    assertThat(repository.credentials.password).isEqualTo("mock-token-publish")
+  }
+
+  @Test
+  fun `incomplete service credentials fail with a descriptive error`() {
+    // Given
+    System.setProperty("codeartifact.accessKeyId", "AKIAIOSFODNN7EXAMPLE")
+
+    val project = ProjectBuilder.builder().build()
+    project.plugins.apply("ai.clarity.codeartifact")
+
+    val codeArtifactUrl = "https://my-domain-111122223333.d.codeartifact.us-west-2.amazonaws.com/maven/my-repo/"
+
+    // When/Then
+    assertThatThrownBy {
+      project.repositories.maven { repo ->
+        repo.url = URI(codeArtifactUrl)
+      }
+    }
+      .isInstanceOf(InvalidUserDataException::class.java)
+      .hasMessageContaining("codeartifact.secretAccessKey")
+  }
 }

--- a/src/test/kotlin/ai/clarity/codeartifact/CodeArtifactSettingsPluginTest.kt
+++ b/src/test/kotlin/ai/clarity/codeartifact/CodeArtifactSettingsPluginTest.kt
@@ -23,6 +23,8 @@ class CodeArtifactSettingsPluginTest {
   @AfterEach
   fun tearDown() {
     unmockkAll()
+    System.clearProperty("codeartifact.accessKeyId")
+    System.clearProperty("codeartifact.secretAccessKey")
   }
 
   @Test
@@ -33,7 +35,7 @@ class CodeArtifactSettingsPluginTest {
       .build()
 
     mockkStatic(TokenFactory::class)
-    every { TokenFactory.getAuthorizationToken(any<CodeArtifactUrl>(), any()) } returns mockResponse
+    every { TokenFactory.getAuthorizationToken(any<CodeArtifactUrl>(), any<String>()) } returns mockResponse
 
     val settings = mockk<Settings>(relaxed = true)
     val gradle = mockk<Gradle>(relaxed = true)
@@ -81,7 +83,7 @@ class CodeArtifactSettingsPluginTest {
     assertThat(repository.credentials.username).isEqualTo("aws")
     assertThat(repository.credentials.password).isEqualTo("mock-settings-token")
 
-    verify(exactly = 1) { TokenFactory.getAuthorizationToken(any<CodeArtifactUrl>(), any()) }
+    verify(exactly = 1) { TokenFactory.getAuthorizationToken(any<CodeArtifactUrl>(), any<String>()) }
   }
 
   @Test
@@ -92,7 +94,7 @@ class CodeArtifactSettingsPluginTest {
       .build()
 
     mockkStatic(TokenFactory::class)
-    every { TokenFactory.getAuthorizationToken(any<CodeArtifactUrl>(), any()) } returns mockResponse
+    every { TokenFactory.getAuthorizationToken(any<CodeArtifactUrl>(), any<String>()) } returns mockResponse
 
     val settings = mockk<Settings>(relaxed = true)
     val gradle = mockk<Gradle>(relaxed = true)
@@ -139,7 +141,7 @@ class CodeArtifactSettingsPluginTest {
     assertThat(repository.credentials.username).isEqualTo("aws")
     assertThat(repository.credentials.password).isEqualTo("mock-dep-token")
 
-    verify(exactly = 1) { TokenFactory.getAuthorizationToken(any<CodeArtifactUrl>(), any()) }
+    verify(exactly = 1) { TokenFactory.getAuthorizationToken(any<CodeArtifactUrl>(), any<String>()) }
   }
 
   @Test
@@ -196,7 +198,7 @@ class CodeArtifactSettingsPluginTest {
     assertThat(depRepo.credentials.username).isNull()
     assertThat(depRepo.credentials.password).isNull()
 
-    verify(exactly = 0) { TokenFactory.getAuthorizationToken(any<CodeArtifactUrl>(), any()) }
+    verify(exactly = 0) { TokenFactory.getAuthorizationToken(any<CodeArtifactUrl>(), any<String>()) }
   }
 
   @Test
@@ -247,7 +249,7 @@ class CodeArtifactSettingsPluginTest {
       .build()
 
     mockkStatic(TokenFactory::class)
-    every { TokenFactory.getAuthorizationToken(any<CodeArtifactUrl>(), any()) } returns mockResponse
+    every { TokenFactory.getAuthorizationToken(any<CodeArtifactUrl>(), any<String>()) } returns mockResponse
 
     val settings = mockk<Settings>(relaxed = true)
     val gradle = mockk<Gradle>(relaxed = true)
@@ -297,7 +299,68 @@ class CodeArtifactSettingsPluginTest {
     // Then - credentials should remain unchanged
     assertThat(repository.credentials.username).isEqualTo("existing-user")
     assertThat(repository.credentials.password).isEqualTo("existing-pass")
-    verify(exactly = 0) { TokenFactory.getAuthorizationToken(any<CodeArtifactUrl>(), any()) }
+    verify(exactly = 0) { TokenFactory.getAuthorizationToken(any<CodeArtifactUrl>(), any<String>()) }
+  }
+
+  @Test
+  fun `settings plugin uses the service credentials of the build`() {
+    // Given
+    System.setProperty("codeartifact.accessKeyId", "AKIAIOSFODNN7EXAMPLE")
+    System.setProperty("codeartifact.secretAccessKey", "service-user-secret")
+
+    val credentials = CodeArtifactCredentials.of("AKIAIOSFODNN7EXAMPLE", "service-user-secret")
+
+    mockkStatic(TokenFactory::class)
+    every { TokenFactory.getAuthorizationToken(any<CodeArtifactUrl>(), credentials) } returns
+      GetAuthorizationTokenResponse.builder().authorizationToken("mock-service-user-token").build()
+
+    val settings = mockk<Settings>(relaxed = true)
+    val gradle = mockk<Gradle>(relaxed = true)
+    val buildServiceRegistry = mockk<BuildServiceRegistry>(relaxed = true)
+    val serviceProvider = mockk<Provider<CodeArtifactToken>>(relaxed = true)
+    val codeArtifactToken = CodeArtifactToken()
+
+    every { settings.gradle } returns gradle
+    every { gradle.sharedServices } returns buildServiceRegistry
+    every {
+      buildServiceRegistry.registerIfAbsent(
+        any(),
+        any<Class<CodeArtifactToken>>(),
+        any()
+      )
+    } returns serviceProvider
+    every { serviceProvider.get() } returns codeArtifactToken
+
+    val pluginManagementProject = ProjectBuilder.builder().build()
+    val dependencyResolutionProject = ProjectBuilder.builder().build()
+
+    val pluginManagement = mockk<org.gradle.plugin.management.PluginManagementSpec>(relaxed = true)
+    val dependencyResolutionManagement =
+      mockk<org.gradle.api.initialization.resolve.DependencyResolutionManagement>(relaxed = true)
+
+    every { settings.pluginManagement } returns pluginManagement
+    every { pluginManagement.repositories } returns pluginManagementProject.repositories
+    every { settings.dependencyResolutionManagement } returns dependencyResolutionManagement
+    every { dependencyResolutionManagement.repositories } returns dependencyResolutionProject.repositories
+
+    val codeArtifactUrl = "https://my-domain-111122223333.d.codeartifact.us-west-2.amazonaws.com/maven/my-repo/"
+
+    // When
+    val plugin = CodeArtifactSettingsPlugin()
+    plugin.apply(settings)
+
+    pluginManagementProject.repositories.maven { repo ->
+      repo.url = URI(codeArtifactUrl)
+    }
+
+    val repository = pluginManagementProject.repositories.first() as MavenArtifactRepository
+
+    // Then
+    assertThat(repository.credentials.username).isEqualTo("aws")
+    assertThat(repository.credentials.password).isEqualTo("mock-service-user-token")
+
+    verify(exactly = 1) { TokenFactory.getAuthorizationToken(any<CodeArtifactUrl>(), credentials) }
+    verify(exactly = 0) { TokenFactory.getAuthorizationToken(any<CodeArtifactUrl>(), any<String>()) }
   }
 
 }

--- a/src/test/kotlin/ai/clarity/codeartifact/CodeArtifactTokenTest.kt
+++ b/src/test/kotlin/ai/clarity/codeartifact/CodeArtifactTokenTest.kt
@@ -30,6 +30,7 @@ import java.net.URI
 class CodeArtifactTokenTest {
 
   private val codeArtifactUrl = "https://my-domain-111122223333.d.codeartifact.us-west-2.amazonaws.com/maven/my-repo/"
+  private val credentials = CodeArtifactCredentials.of("AKIAIOSFODNN7EXAMPLE", "secret")
 
   @AfterEach
   fun tearDown() {
@@ -117,5 +118,66 @@ class CodeArtifactTokenTest {
     assertThat(fromUri).isEqualTo("tok-uri")
     assertThat(fromString).isEqualTo("tok-uri")
     verify(exactly = 1) { TokenFactory.getAuthorizationToken(any<CodeArtifactUrl>(), "default") }
+  }
+
+  @Test
+  fun `token is fetched only once for the same url and service credentials`() {
+    // Given
+    mockkStatic(TokenFactory::class)
+    every { TokenFactory.getAuthorizationToken(any<CodeArtifactUrl>(), credentials) } returns
+      GetAuthorizationTokenResponse.builder().authorizationToken("tok-credentials").build()
+
+    val service = CodeArtifactToken()
+
+    // When
+    val first = service.getToken(codeArtifactUrl, credentials)
+    val second = service.getToken(URI(codeArtifactUrl), credentials)
+
+    // Then
+    assertThat(first).isEqualTo("tok-credentials")
+    assertThat(second).isEqualTo("tok-credentials")
+    verify(exactly = 1) { TokenFactory.getAuthorizationToken(any<CodeArtifactUrl>(), credentials) }
+  }
+
+  @Test
+  fun `token is fetched separately for each set of service credentials on the same url`() {
+    // Given
+    val otherCredentials = CodeArtifactCredentials.of("AKIAANOTHEREXAMPLE00", "other-secret")
+
+    mockkStatic(TokenFactory::class)
+    every { TokenFactory.getAuthorizationToken(any<CodeArtifactUrl>(), credentials) } returns
+      GetAuthorizationTokenResponse.builder().authorizationToken("tok-service-user").build()
+    every { TokenFactory.getAuthorizationToken(any<CodeArtifactUrl>(), otherCredentials) } returns
+      GetAuthorizationTokenResponse.builder().authorizationToken("tok-other-service-user").build()
+
+    val service = CodeArtifactToken()
+
+    // When
+    val token = service.getToken(codeArtifactUrl, credentials)
+    val otherToken = service.getToken(codeArtifactUrl, otherCredentials)
+
+    // Then
+    assertThat(token).isEqualTo("tok-service-user")
+    assertThat(otherToken).isEqualTo("tok-other-service-user")
+  }
+
+  @Test
+  fun `service credentials and profiles do not share cache entries`() {
+    // Given
+    mockkStatic(TokenFactory::class)
+    every { TokenFactory.getAuthorizationToken(any<CodeArtifactUrl>(), "default") } returns
+      GetAuthorizationTokenResponse.builder().authorizationToken("tok-profile").build()
+    every { TokenFactory.getAuthorizationToken(any<CodeArtifactUrl>(), credentials) } returns
+      GetAuthorizationTokenResponse.builder().authorizationToken("tok-credentials").build()
+
+    val service = CodeArtifactToken()
+
+    // When
+    val profileToken = service.getToken(codeArtifactUrl, "default")
+    val credentialsToken = service.getToken(codeArtifactUrl, credentials)
+
+    // Then
+    assertThat(profileToken).isEqualTo("tok-profile")
+    assertThat(credentialsToken).isEqualTo("tok-credentials")
   }
 }


### PR DESCRIPTION
# Authenticate CodeArtifact with the credentials of a service account

## Motivation

Today the plugin can only authenticate through a local AWS profile. That works well on a developer
machine, but leaves a gap for CI/CD and for any environment that has no `~/.aws/credentials`:

- The AWS SDK default chain does pick up `AWS_ACCESS_KEY_ID` / `AWS_SECRET_ACCESS_KEY`, but only when
  no profile is resolved at all. As soon as `?profile=`, `codeartifact.profile` or `CODEARTIFACT_PROFILE`
  is set, the plugin builds a `ProfileCredentialsProvider`, which ignores static access keys.
- The `codeartifact()` helper always passed `"default"` as the profile, so it *always* built a
  `ProfileCredentialsProvider("default")`. Static credentials could never reach it, whatever the environment.
- There is no way to keep the CodeArtifact credentials separate from the AWS credentials used by the rest
  of the build. The plugin already offers `CODEARTIFACT_PROFILE` for exactly that reason, but has no
  static equivalent.
- There is no way to source the credentials from `gradle.properties` / system properties, which the
  profile support already offers.

This PR closes that gap: a build can now authenticate with the static access keys of a service account
(an IAM user, or a set of temporary credentials with a session token).

## What this adds

### For the whole build

Each value is read from its system property first, and from its environment variable second:

| Value             | System property                | Environment variable             | Required                       |
|-------------------|--------------------------------|----------------------------------|--------------------------------|
| Access key id     | `codeartifact.accessKeyId`     | `CODEARTIFACT_ACCESS_KEY_ID`     | Yes                            |
| Secret access key | `codeartifact.secretAccessKey` | `CODEARTIFACT_SECRET_ACCESS_KEY` | Yes                            |
| Session token     | `codeartifact.sessionToken`    | `CODEARTIFACT_SESSION_TOKEN`     | Only for temporary credentials |

Once set, they apply to every CodeArtifact repository of the build, including the ones declared in
`settings.gradle(.kts)` under `pluginManagement` and `dependencyResolutionManagement`.

Setting only one of the two required values fails the build with an explicit message naming the missing
one, instead of silently falling back to another set of credentials.

### For a single repository

The `codeartifact()` helper now accepts the credentials directly, for builds whose repositories belong to
different AWS accounts.

Kotlin DSL:

```kotlin
repositories {
    codeartifact(
        "https://domain-id.d.codeartifact.eu-central-1.amazonaws.com/maven/repository/",
        CodeArtifactCredentials.of(
            providers.gradleProperty("codeArtifactAccessKeyId").get(),
            providers.gradleProperty("codeArtifactSecretAccessKey").get()
        )
    )
}
```

Groovy DSL, where a plain map is the idiomatic shape:

```groovy
repositories {
    codeartifact('https://domain-id.d.codeartifact.eu-central-1.amazonaws.com/maven/repository/', [
            accessKeyId    : providers.gradleProperty('codeArtifactAccessKeyId').get(),
            secretAccessKey: providers.gradleProperty('codeArtifactSecretAccessKey').get()
    ])
}
```

## Resolution order

The rule is: the configuration closest to the repository wins, and at the same level static credentials
win over profiles.

1. Credentials passed to the `codeartifact()` helper
2. Profile passed to the `codeartifact()` helper, or `?profile=` query parameter in the repository URL
3. `codeartifact.accessKeyId` and `codeartifact.secretAccessKey`, each read from the system property first
   and from the matching `CODEARTIFACT_*` environment variable second
4. `codeartifact.profile` Java system property
5. `CODEARTIFACT_PROFILE` environment variable
6. The AWS SDK default credentials provider chain for the repositories detected automatically, and the
   `default` profile for the ones declared with the `codeartifact()` helper

Steps 1, 2 and 4 to 6 are the existing behaviour, unchanged. Only step 3 is new.

## Security considerations

These were deliberate design choices, happy to discuss any of them:

- **No query parameter for the credentials.** `?profile=` is fine because a profile name is not a secret;
  a secret access key is, and the repository URL ends up in build scans, caches and logs. The only ways in
  are system properties, environment variables, and the DSL.
- **Nothing sensitive is logged.** The build log gets a masked access key id (`AKIA************MPLE`), never
  the secret. `CodeArtifactCredentials.toString()` is redacted too, so the secret cannot leak through a
  Gradle error message either.
- **The token cache key is a SHA-256 digest** of the credentials rather than the values themselves, so no
  secret is held in clear as a map key, and two different service accounts can never share a cached token.
- **Values that are not `CharSequence` are rejected** with a message that names the offending key and its
  type, never its value — this catches passing a Gradle `Provider` by mistake instead of silently
  authenticating with `"provider(?)"`.

## Backward compatibility

One signature changed:

```diff
 fun RepositoryHandler.codeartifact(
   repoUrl: String,
-  profile: String = "default",
+  profile: String? = null,
   action: Action<in MavenArtifactRepository>? = null
 )
```

This is needed to tell "no profile specified" apart from "the profile named `default`". It is source
compatible, and behaviour is unchanged: with no service credentials configured, an omitted profile still
falls back to `default`. The pre-existing functional tests covering that fallback were not touched and
still pass.

The Groovy `doCall` overloads were reorganised around a shared private method, which also removes the
duplication between the three call shapes.

## Tests

115 -> 171 tests, all green.

**Unit tests (44 -> 86)**

- `CodeArtifactCredentialsTest` (21, new) — creation, map conversion, validation, redaction, cache key.
  Explicitly asserts that the secret appears in neither `toString()` nor the cache key.
- `CodeArtifactCredentialsResolverTest` (8, new) — system properties, environment variables, per-value
  precedence, blank values, and both incomplete-configuration errors. The lookups are injected, so the
  environment variable cases run without mutating the JVM.
- `CodeArtifactTokenTest` (+3) — caching per credentials set, and no collision between a profile entry and
  a credentials entry for the same URL.
- `CodeArtifactProjectPluginTest` (+6), `ClarityCodeArtifactGradlePluginTest` (+3),
  `CodeArtifactSettingsPluginTest` (+1) — the resolution order at each entry point, in both directions.

**Functional tests (71 -> 85)**

A new `ServiceCredentialsFunctionalTest` with 14 cases:

- Two end-to-end runs against a stubbed `GetAuthorizationToken` endpoint, one driven by environment
  variables and one by `gradle.properties`, both with `AWS_ACCESS_KEY_ID`, `AWS_SECRET_ACCESS_KEY` and
  `AWS_PROFILE` removed from the environment. If the plugin ignored the `CODEARTIFACT_*` configuration the
  SDK would find no credentials at all and the build would fail, so these tests cannot pass by accident.
- A repository `?profile=` keeping precedence over build-wide service credentials.
- Incomplete credentials producing the expected error message.
- The Kotlin and Groovy DSL forms, each across all five Gradle versions already covered by the suite
  (8.4, 8.7, 8.14, 9.1.0, 9.4.0), asserting that the secret never appears in the output.

The existing `TokenEndpointFunctionalTest` now shares the endpoint stub and the build script template with
the new class instead of duplicating them.

Beyond the suite, the change was verified end-to-end against a real CodeArtifact domain in a real
multi-project build, for both dependency resolution and publishing.

## Documentation

- New "Service account credentials" section in the README: the table above, CI/CD and local setup, both
  DSLs, and the warning about never committing the values.
- "Profile resolution order" became "Credentials resolution order" with the full list.
- The `codeartifact()` helper section mentions the new overload, and now also documents the imports it
  needs in `build.gradle.kts` — previously missing.

## Out of scope

While working on this I noticed that the `codeartifact()` helper ignores `codeartifact.profile` and
`CODEARTIFACT_PROFILE` and always falls back to the `default` profile, whereas automatic detection honours
them. That looks like a bug, but fixing it changes existing behaviour, so I left it out of this PR rather
than folding a behaviour change into a feature. Happy to open a separate one if you agree it should be
fixed.

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)
