### PR TITLE
docs: correct the settings-DSL claims and the resolution order

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,5 +1,8 @@
 name: Java CI
-on: [ push ]
+on:
+  push:
+    branches: [ main ]
+  pull_request:
 permissions:
   checks: write
   contents: read

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -34,13 +34,13 @@ All verified on this checkout (`main`, 2026-09-01).
 
 ```bash
 ./gradlew build            # compile + unit tests + functionalTest + validatePlugins
-./gradlew test             # 44 unit tests
-./gradlew functionalTest   # 71 TestKit tests across Gradle 8.4, 8.7, 8.14, 9.1.0, 9.4.0
+./gradlew test             # 86 unit tests
+./gradlew functionalTest   # 85 TestKit tests across Gradle 8.4, 8.7, 8.14, 9.1.0, 9.4.0
 ./gradlew publishToMavenLocal   # for trying the plugin from a scratch project
 ./gradlew tasks --all
 ```
 
-`./gradlew build` from clean: ~1m30s (`functionalTest` dominates — it boots five Gradle
+`./gradlew build` from clean: ~4m (`functionalTest` dominates — it boots five Gradle
 distributions). Tests are heavily `UP-TO-DATE`-cached; add `--rerun-tasks` when you need proof
 they actually ran.
 
@@ -63,8 +63,11 @@ src/main/kotlin/ai/clarity/codeartifact/
   CodeArtifactProjectPlugin.kt         # Project target: repositories + publishing repositories
   CodeArtifactSettingsPlugin.kt        # Settings target: pluginManagement + DRM repositories
   CodeartifactRepositoryConfigurer.kt  # shared logic: detect, resolve profile, inject creds
+  CodeArtifactAuthenticator.kt         # picks credentials vs profile for one repository
+  CodeArtifactCredentialsResolver.kt   # build-wide service credentials from sysprops/env
 src/main/java/ai/clarity/codeartifact/
-  CodeArtifactToken.java               # Gradle BuildService, caches tokens by "profile@url"
+  CodeArtifactToken.java               # Gradle BuildService, caches tokens per auth+url
+  CodeArtifactCredentials.java         # static service-account keys: masking, redaction, cache key
   TokenFactory.java                    # AWS SDK GetAuthorizationToken call
   CodeArtifactUrl.java                 # host parsing -> domain / owner / region
   URIBuilder.java                      # immutable-ish URI query-param editing
@@ -98,11 +101,23 @@ experiments):
 1. Non-CodeArtifact repositories are left completely untouched (credentials stay `null`).
 2. A CodeArtifact repository that **already has credentials** is skipped.
 3. `?profile=<name>` is read from the URL and then **stripped** from the final repository URL.
-4. Profile precedence: `?profile=` → `-Dcodeartifact.profile` / `systemProp.codeartifact.profile`
-   → `CODEARTIFACT_PROFILE` → *null* (AWS default chain, which honours `AWS_PROFILE`).
-5. Tokens are fetched **once per `profile@url`** and shared through a Gradle `BuildService`.
+4. Credentials precedence, closest-to-the-repository first: credentials passed to
+   `codeartifact()` → `?profile=` or a profile passed to `codeartifact()` →
+   `codeartifact.accessKeyId`/`secretAccessKey` (system property, then `CODEARTIFACT_*` env) →
+   `-Dcodeartifact.profile` / `systemProp.codeartifact.profile` → `CODEARTIFACT_PROFILE` →
+   *null* (AWS default chain, which honours `AWS_PROFILE`). The last two steps apply to
+   automatically detected repositories only; the `codeartifact()` helper falls back to the
+   `default` profile instead.
+5. Tokens are fetched **once per authentication + url** and shared through a Gradle
+   `BuildService`. Profile entries and service-credential entries never share a cache slot, and
+   the credentials half of the key is a SHA-256 digest so no secret is held in clear.
 6. A URL that looks like CodeArtifact but cannot be parsed **fails the build** with
    `Not a valid CodeArtifact repository URL: … (expected format: …)`.
+7. **No secret ever reaches the build log.** Only a masked access key id
+   (`AKIA************MPLE`) is logged, `CodeArtifactCredentials.toString()` is redacted, and a
+   half-configured credential pair fails with `Incomplete CodeArtifact service credentials`
+   rather than falling back silently. Verified at `--debug --stacktrace`: 0 occurrences of the
+   secret in 6249 log lines.
 
 ## Known gaps — do not document these as working
 
@@ -111,20 +126,18 @@ experiments):
   `maven { url = ".../codeartifact.<region>.on.aws/..." }` silently gets no credentials. The
   explicit `codeartifact(...)` helper *does* work with dualstack URLs.
 - **VPC endpoints are unsupported by design** (domain/owner live in the path, not the host).
-- **`codeartifact(url)` hardcodes the profile `"default"`** — it ignores
-  `codeartifact.profile`, `CODEARTIFACT_PROFILE` and `AWS_PROFILE`. Pass the profile explicitly.
-- **The Kotlin DSL helper needs `import ai.clarity.codeartifact.codeartifact`.** The README's
-  Kotlin examples omit it and therefore do not compile.
+- **`codeartifact(url)` with no profile falls back to the `default` profile** — it honours the
+  build-wide service credentials, but still ignores `codeartifact.profile`,
+  `CODEARTIFACT_PROFILE` and `AWS_PROFILE`, unlike automatic detection. Pass the profile
+  explicitly. Known inconsistency, deliberately left alone so far.
+- **The Kotlin DSL needs explicit imports**: `ai.clarity.codeartifact.codeartifact` for the
+  helper and `ai.clarity.codeartifact.CodeArtifactCredentials` for the credentials class.
+- **The `codeartifact()` helper does not work inside `pluginManagement`** (that block runs
+  before `plugins { }` applies the plugin). It does work inside
+  `dependencyResolutionManagement`, in both DSLs.
 - **No linter or formatter** is wired into the build; `./gradlew check` will not catch style.
 
 ## README caveats
 
-`README.md` is mostly accurate but has three defects — fix them only if asked:
-
-1. All examples pin `version "0.1.1"`; the latest published version is **0.1.2**
-   (working version here is `0.1.3-SNAPSHOT`).
-2. It claims the `codeartifact` helper is "**NOT available** in `settings.gradle(.kts)`".
-   Verified false: it works inside `dependencyResolutionManagement` in both DSLs. It genuinely
-   does *not* work inside `pluginManagement`, because that block is evaluated before `plugins {}`
-   applies the plugin.
-3. The Kotlin `codeartifact(...)` snippets are missing the required import.
+One defect left — fix it only if asked: all examples pin `version "0.1.1"`, while the latest
+published version is **0.1.2** (the working version here is `0.1.3-SNAPSHOT`).

--- a/README.md
+++ b/README.md
@@ -94,7 +94,9 @@ Instead of relying on automatic detection via `maven { url ... }`, you can use t
 directly on the `repositories` block. This method accepts the repository URL, an optional profile name or the
 [credentials of a service account](#service-account-credentials), and an optional configuration closure/action.
 
-> **Note:** The `Explicit codeartifact method` can only be used inside the `build.gradle` or `build.gradle.kts` files.
+> **Note:** The `codeartifact()` helper can be used in `build.gradle(.kts)`, and in `settings.gradle(.kts)` inside
+> `dependencyResolutionManagement`. It cannot be used inside `pluginManagement`, which Gradle evaluates before the
+> `plugins { }` block applies this plugin. Use `maven { url ... }` there and rely on automatic detection.
 
 ### Kotlin DSL
 
@@ -151,7 +153,9 @@ repositories {
 Applying the plugin in `settings.gradle.kts` or `settings.gradle` allows you to centralize repository configuration for all projects in the
 build, including `pluginManagement` and `dependencyResolutionManagement`.
 
-> **Note:** The `codeartifact` helper method is **NOT available** in `settings.gradle(.kts)`. You must use the standard `maven { url ... }` approach for automatic detection instead.
+> **Note:** Inside `pluginManagement` the `codeartifact()` helper is not available, because Gradle evaluates that
+> block before the `plugins { }` block applies this plugin. Use the standard `maven { url ... }` approach there and
+> rely on automatic detection. Inside `dependencyResolutionManagement` the helper does work.
 
 #### Kotlin DSL
 
@@ -392,8 +396,9 @@ repositories {
 }
 ```
 
-> **Note:** as for the profile, the `codeartifact()` helper is not available in `settings.gradle(.kts)`. Use the
-> build-wide configuration above for the repositories declared there.
+> **Note:** the `codeartifact()` helper also works in `settings.gradle(.kts)` inside
+> `dependencyResolutionManagement`, but not inside `pluginManagement`. Use the build-wide configuration above for
+> the repositories declared there.
 
 ## Credentials resolution order
 
@@ -406,8 +411,15 @@ the same level:
    matching `CODEARTIFACT_*` environment variable second
 4. `codeartifact.profile` Java system property
 5. `CODEARTIFACT_PROFILE` environment variable
-6. The AWS SDK default credentials provider chain (`AWS_PROFILE`, `AWS_ACCESS_KEY_ID`, instance roles, …) for the
-   repositories detected automatically, and the `default` profile for the ones declared with the `codeartifact()` helper
+6. The AWS SDK default credentials provider chain (`AWS_PROFILE`, `AWS_ACCESS_KEY_ID`, instance roles, …)
+
+> **Note:** steps 4 and 5 only apply to the repositories detected automatically. A repository declared with the
+> `codeartifact()` helper and no explicit profile falls back to the `default` profile instead, so `codeartifact.profile`
+> and `CODEARTIFACT_PROFILE` have no effect on it. Pass the profile to the helper if you need another one.
+
+The incomplete-configuration check on step 3 runs only when steps 1 and 2 did not already settle the authentication:
+with a `?profile=` in the URL, or a profile passed to the helper, a half-configured pair of service credentials is
+ignored rather than reported.
 
 ## License
 

--- a/docs/ONBOARDING.md
+++ b/docs/ONBOARDING.md
@@ -9,7 +9,7 @@ Consumers declare an ordinary Maven repository pointing at an AWS CodeArtifact e
 Gradle **configuration time** the plugin:
 
 1. spots repositories whose URL matches `.+\.codeartifact\..+\.amazonaws\..+` (case-insensitive);
-2. resolves which AWS profile to use;
+2. resolves how to authenticate — the static keys of a service account, or an AWS profile;
 3. calls `codeartifact:GetAuthorizationToken` through the AWS SDK v2;
 4. sets `username = "aws"`, `password = <token>` on the repository;
 5. removes the `?profile=` query parameter from the URL so AWS never sees it.
@@ -23,7 +23,7 @@ There is no task, no extension block, and nothing for the consumer to invoke.
 | JDK to build | 21 (Gradle toolchain; the launcher JVM may be newer — verified on JDK 25) |
 | Gradle to build | wrapper, 9.7.1 |
 | Gradle to consume | 8.4+ documented and tested (8.3 also works in practice, see §7) |
-| AWS | a resolvable credential chain — profile, SSO, env vars, instance role… |
+| AWS | a resolvable credential chain — service-account keys (§5), profile, SSO, env vars, instance role… |
 
 Building this repo itself needs **no AWS access**: it resolves only from Maven Central.
 
@@ -52,12 +52,20 @@ Gradle cannot run inside the Claude Code sandbox — disable it for every `./gra
                                      │    Groovy closure + stashes the    │
                                      │    BuildService in extraProperties │
                                      │  · withType(Maven…).configureEach: │
-                                     │    detect ▸ profile ▸ token ▸ creds│
+                                     │    detect ▸ authenticate ▸ creds   │
+                                     └───────────────┬────────────────────┘
+                                                     │ delegates the choice to
+                                     ┌───────────────▼────────────────────┐
+                                     │ CodeArtifactAuthenticator          │
+                                     │   repo credentials ▸ repo profile  │
+                                     │   ▸ CodeArtifactCredentialsResolver│
+                                     │     (build-wide static keys)       │
+                                     │   ▸ fallback profile               │
                                      └───────────────┬────────────────────┘
                                                      │
                        ┌─────────────────────────────▼──────────────────┐
                        │ CodeArtifactToken  (Gradle BuildService)        │
-                       │   ConcurrentHashMap<"profile@url", token>       │
+                       │   ConcurrentHashMap<auth+url, token>            │
                        └───────────────┬────────────────────────────────┘
                                        │
                     CodeArtifactUrl ───┴──▶ TokenFactory ──▶ AWS CodeArtifact
@@ -73,15 +81,22 @@ Gradle cannot run inside the Claude Code sandbox — disable it for every `./gra
 | `ClarityCodeArtifactGradlePlugin.kt` | `implementationClass` in `build.gradle.kts`; a `Plugin<Any>` that dispatches on target type. Also declares the top-level Kotlin extension `RepositoryHandler.codeartifact(url, profile, action)`. |
 | `CodeArtifactProjectPlugin.kt` | Configures `project.repositories` and, when `maven-publish` is present, `publishing.repositories`. |
 | `CodeArtifactSettingsPlugin.kt` | Configures `settings.pluginManagement.repositories` and `settings.dependencyResolutionManagement.repositories`. |
-| `CodeartifactRepositoryConfigurer.kt` | The only place detection, profile resolution and credential injection live. |
+| `CodeartifactRepositoryConfigurer.kt` | The only place detection and credential injection live. |
+| `CodeArtifactAuthenticator.kt` | The only place the precedence between repository credentials, repository profile, build-wide service credentials and fallback profile is decided. |
+| `CodeArtifactCredentialsResolver.kt` | Reads the build-wide service-account keys from system properties, then environment variables. Takes the lookups as parameters so tests need not mutate the JVM. |
 
 ### Support classes (Java)
 
-- **`CodeArtifactToken`** — `BuildService<None>`, registered as `"codeartifact-token"`, caching
-  by `profile + "@" + url`. One token per profile/URL pair per build, shared across projects.
-- **`TokenFactory`** — builds a `CodeartifactClient` for the URL's region. If `profileName` is
-  non-null it forces `ProfileCredentialsProvider.create(profile)`; if null it leaves the AWS
-  default credential chain in place (which is how `AWS_PROFILE`, SSO and instance roles work).
+- **`CodeArtifactToken`** — `BuildService<None>`, registered as `"codeartifact-token"`, caching by
+  `"profile:<name>@<url>"` or `"credentials:<sha256>@<url>"`. One token per authentication/URL
+  pair per build, shared across projects; the two key shapes cannot collide.
+- **`CodeArtifactCredentials`** — the static service-account keys. Rejects blank values and
+  non-`CharSequence` map entries (naming the key and its type, never its value), exposes only a
+  masked access key id, redacts `toString()`, and derives the cache key from a SHA-256 digest.
+- **`TokenFactory`** — builds a `CodeartifactClient` for the URL's region. With credentials it
+  installs a `StaticCredentialsProvider`; with a non-null profile name a
+  `ProfileCredentialsProvider`; with neither it leaves the AWS default credential chain in place
+  (which is how `AWS_PROFILE`, SSO and instance roles work).
 - **`CodeArtifactUrl`** — parses the host with
   `^([^.]+)-([^-.]+)\.d\.codeartifact\.([^.]+)\.(?:amazonaws\..+|on\.aws)$`, yielding
   domain / owner / region. Rejects anything else with a `MalformedURLException` naming the
@@ -124,42 +139,92 @@ repositories {
 }
 ```
 
+The helper also takes the static credentials of a service account instead of a profile:
+
+```kotlin
+import ai.clarity.codeartifact.CodeArtifactCredentials
+import ai.clarity.codeartifact.codeartifact
+
+repositories {
+  codeartifact(
+    "https://my-domain-111122223333.d.codeartifact.us-west-2.amazonaws.com/maven/my-repo/",
+    CodeArtifactCredentials.of(accessKeyId, secretAccessKey)   // third arg: sessionToken
+  )
+}
+```
+
+```groovy
+// Groovy takes a map, and rejects an unknown key by name
+repositories {
+  codeartifact('https://…/maven/my-repo/', [accessKeyId: id, secretAccessKey: secret])
+}
+```
+
 Two traps:
 
-- **Without the Kotlin import you get `Unresolved reference 'codeartifact'`** (a fully-qualified
+- **Without the Kotlin imports you get `Unresolved reference 'codeartifact'`** (a fully-qualified
   `ai.clarity.codeartifact.codeartifact(...)` call does not work either — it is an extension
-  function).
-- **The profile defaults to the literal `"default"`**, not to the resolution chain below. With
-  `CODEARTIFACT_PROFILE=dev` set, `codeartifact(url)` still logs
-  `in profile default`. Pass the profile explicitly if you need another one.
+  function). `CodeArtifactCredentials` needs its own import.
+- **With no profile and no service credentials the helper falls back to the literal `"default"`
+  profile**, not to the rest of the chain below. With `CODEARTIFACT_PROFILE=dev` set,
+  `codeartifact(url)` still logs `in profile default`. Pass the profile explicitly if you need
+  another one. Build-wide service credentials *are* honoured on this path.
 
 Both work in `dependencyResolutionManagement` inside `settings.gradle(.kts)` too, but **not**
 in `pluginManagement`: that block is evaluated before `plugins { }` applies the plugin, so the
 method does not exist yet (`Could not find method codeartifact()`).
 
-## 5. Profile resolution
+## 5. Credentials resolution
 
-Verified order, highest precedence first:
+Verified order, highest precedence first. Steps 1 and 2 are per repository, the rest are
+build-wide:
 
 | # | Source | Verified behaviour |
 |---|---|---|
-| 1 | `?profile=<name>` in the repository URL | wins over everything; stripped from the final URL |
-| 2 | `-Dcodeartifact.profile=<name>` / `systemProp.codeartifact.profile=<name>` in `gradle.properties` | command line overrides the properties file |
-| 3 | `CODEARTIFACT_PROFILE` env var | used when 1 and 2 are absent |
-| 4 | nothing → profile is `null` | the AWS SDK default chain runs, so `AWS_PROFILE`, SSO caches and instance roles apply |
+| 1 | `CodeArtifactCredentials` passed to `codeartifact()` (Kotlin) or a credentials map (Groovy) | wins over everything |
+| 2 | `?profile=<name>` in the URL, or a profile passed to `codeartifact()` | beats every build-wide setting; the query param is stripped from the final URL |
+| 3 | `codeartifact.accessKeyId` + `codeartifact.secretAccessKey` (`systemProp.`/`-D`), else `CODEARTIFACT_ACCESS_KEY_ID` + `CODEARTIFACT_SECRET_ACCESS_KEY` | static service-account keys; optional `codeartifact.sessionToken` / `CODEARTIFACT_SESSION_TOKEN` for temporary ones |
+| 4 | `-Dcodeartifact.profile=<name>` / `systemProp.codeartifact.profile=<name>` | command line overrides the properties file |
+| 5 | `CODEARTIFACT_PROFILE` env var | used when 1-4 are absent |
+| 6 | nothing → profile is `null` | the AWS SDK default chain runs, so `AWS_PROFILE`, `AWS_ACCESS_KEY_ID`, SSO caches and instance roles apply |
+
+Two asymmetries worth knowing, both measured:
+
+- **Steps 4 and 5 apply to automatic detection only.** A repository declared with
+  `codeartifact()` and no explicit profile falls back to the `default` profile instead, so
+  `codeartifact.profile` and `CODEARTIFACT_PROFILE` have no effect on it. Step 3 *does* reach it.
+- **Setting exactly one of the two required step-3 values fails the build** with
+  `Incomplete CodeArtifact service credentials: …`, naming the missing half — but only when
+  steps 1 and 2 did not already settle the authentication. With a `?profile=` in the URL the
+  half-configured pair is ignored instead of reported.
 
 `codeartifact.profile` must carry the `systemProp.` prefix in `gradle.properties`; a plain
-`codeartifact.profile=dev` becomes a Gradle project property, which the plugin never reads.
+`codeartifact.profile=dev` becomes a Gradle project property, which the plugin never reads. The
+same applies to `codeartifact.accessKeyId` and `codeartifact.secretAccessKey`.
 
 Recommended pattern for teams: commit `systemProp.codeartifact.profile=dev` and let CI override
 with `-Dcodeartifact.profile=ci`. Do not mix it with `?profile=`, which would defeat the override.
+CI that has no `~/.aws/credentials` at all should export the `CODEARTIFACT_*` keys instead.
+
+### Secret handling
+
+Never put the keys in the project `gradle.properties` — use `~/.gradle/gradle.properties` or the
+CI secret store. There is deliberately no `?accessKeyId=` query param, because the repository URL
+reaches build scans, caches and logs. What the plugin does guarantee, all verified:
+
+- only a masked access key id (`AKIA************MPLE`) is logged, never the secret;
+- `CodeArtifactCredentials.toString()` is redacted, so a Gradle error message cannot leak it;
+- the token cache key hashes the credentials (SHA-256) instead of holding them in clear, and
+  profile entries never collide with service-credential entries;
+- a failing token request at `--debug --stacktrace` produced 6249 log lines with **0**
+  occurrences of the secret and 0 of the unmasked access key id.
 
 ## 6. Testing
 
 ```bash
-./gradlew test --rerun-tasks            # 44 tests, all green
-./gradlew functionalTest --rerun-tasks  # 71 tests, all green
-./gradlew build                         # both + validatePlugins; ~1m30s from clean
+./gradlew test --rerun-tasks            # 86 tests, all green
+./gradlew functionalTest --rerun-tasks  # 85 tests, all green
+./gradlew build                         # both + validatePlugins; ~4m from clean
 ```
 
 - **Unit tests** use `ProjectBuilder` / `ProjectBuilder`-backed settings and
@@ -208,7 +273,7 @@ profile, since `ProfileCredentialsProvider` bypasses `AWS_ACCESS_KEY_ID`.
 
 | Workflow | Trigger | What it does |
 |---|---|---|
-| `.github/workflows/build.yml` | every `push` | JDK 21 (temurin, gradle cache) → `./gradlew build` → publishes the JUnit XML as a check |
+| `.github/workflows/build.yml` | `push` to `main` + every `pull_request` | JDK 21 (temurin, gradle cache) → `./gradlew build` → publishes the JUnit XML as a check. The `pull_request` trigger matters: the repo takes PRs from forks, and a fork push never fires `on: push` in the upstream repo. |
 | `.github/workflows/publish.yml` | push of any **tag** | JDK 21 → appends `gradle.publish.key/secret` from repo secrets to `gradle.properties` → `./gradlew publishPlugins` |
 
 Version lives in `gradle.properties` (`version=0.1.3-SNAPSHOT`). `net.researchgate.release`
@@ -224,23 +289,22 @@ Never run `release` or `publishPlugins` from an agent session — both are outwa
 |---|---|
 | Repository silently unauthenticated, URL ends in `.on.aws` | `isCodeArtifactUri` requires `.amazonaws.`; dualstack endpoints are not auto-detected. Use the explicit `codeartifact(url)` helper, which accepts them. |
 | `Not a valid CodeArtifact repository URL: …` | Host does not match `{domain}-{owner}.d.codeartifact.{region}.…` — e.g. a missing `-{owner}`, or a VPC endpoint. Fails the build by design. |
-| `Unresolved reference 'codeartifact'` | Missing `import ai.clarity.codeartifact.codeartifact` in a `.kts` file. |
+| `Unresolved reference 'codeartifact'` | Missing `import ai.clarity.codeartifact.codeartifact` in a `.kts` file (`CodeArtifactCredentials` needs its own import). |
 | `Could not find method codeartifact()` inside `pluginManagement` | The block runs before the plugin is applied. Use `maven { url = … }` there. |
-| Wrong profile used by `codeartifact(url)` | It hardcodes `"default"`; env vars and system properties are ignored on that path. |
+| Wrong profile used by `codeartifact(url)` | With no profile it falls back to `"default"`; `codeartifact.profile` and `CODEARTIFACT_PROFILE` are ignored on that path, though build-wide service credentials are honoured. |
+| `Incomplete CodeArtifact service credentials: …` | Exactly one of `codeartifact.accessKeyId` / `codeartifact.secretAccessKey` (or their `CODEARTIFACT_*` env equivalents) is set. Set both, or unset both. |
 | `Timeout waiting to lock journal cache` | Gradle running inside the Claude Code sandbox. Disable the sandbox. |
 | Credentials not injected on a CodeArtifact URL | The repository already had a username or password; the plugin skips those. |
 
 ## 10. README discrepancies (as of 2026-09-01)
 
 1. Every example pins `version "0.1.1"`; the latest published version is **0.1.2**.
-2. "The `codeartifact` helper method is **NOT available** in `settings.gradle(.kts)`" — false.
-   It works in `dependencyResolutionManagement` in both DSLs; it fails only in `pluginManagement`.
-3. The Kotlin `codeartifact(...)` snippets omit `import ai.clarity.codeartifact.codeartifact`
-   and therefore do not compile.
-4. Dualstack `.on.aws` endpoints are undocumented and not auto-detected.
-5. The "Profile resolution order" section applies to automatic detection only, not to the
-   explicit `codeartifact()` helper — the README does not say so.
+2. Dualstack `.on.aws` endpoints are undocumented and not auto-detected (see §9).
 
-Everything else in the README (automatic detection, publishing repositories, the four profile
-mechanisms, the `?profile=` stripping, the `gradle.properties` + CI-override pattern) was
-reproduced and holds.
+Three earlier defects are fixed: the false "the helper is not available in `settings.gradle(.kts)`"
+note, the missing Kotlin imports in the `codeartifact(...)` snippets, and the resolution-order
+list that did not say steps 4-5 skip the helper path.
+
+Everything else in the README (automatic detection, publishing repositories, the profile
+mechanisms, the service-account credentials, the `?profile=` stripping, the `gradle.properties` +
+CI-override pattern) was reproduced and holds.

--- a/src/main/java/ai/clarity/codeartifact/CodeArtifactCredentials.java
+++ b/src/main/java/ai/clarity/codeartifact/CodeArtifactCredentials.java
@@ -20,6 +20,7 @@ import java.security.MessageDigest;
 import java.security.NoSuchAlgorithmException;
 import java.util.HexFormat;
 import java.util.LinkedHashSet;
+import java.util.List;
 import java.util.Map;
 import java.util.Objects;
 import java.util.Set;
@@ -40,7 +41,10 @@ public final class CodeArtifactCredentials {
   private static final String SECRET_ACCESS_KEY = "secretAccessKey";
   private static final String SESSION_TOKEN = "sessionToken";
 
-  private static final Set<String> SUPPORTED_KEYS = Set.of(ACCESS_KEY_ID, SECRET_ACCESS_KEY, SESSION_TOKEN);
+  // LinkedHashSet, not Set.of: the iteration order of Set.of varies between JVM runs and this set is rendered in an
+  // error message
+  private static final Set<String> SUPPORTED_KEYS =
+    new LinkedHashSet<>(List.of(ACCESS_KEY_ID, SECRET_ACCESS_KEY, SESSION_TOKEN));
 
   private final String accessKeyId;
   private final String secretAccessKey;

--- a/src/test/kotlin/ai/clarity/codeartifact/CodeArtifactCredentialsTest.kt
+++ b/src/test/kotlin/ai/clarity/codeartifact/CodeArtifactCredentialsTest.kt
@@ -121,7 +121,10 @@ class CodeArtifactCredentialsTest {
         )
       }
         .isInstanceOf(IllegalArgumentException::class.java)
-        .hasMessageContaining("profile")
+        .hasMessage(
+          "Unsupported CodeArtifact credentials [profile], " +
+            "expected any of [accessKeyId, secretAccessKey, sessionToken]"
+        )
     }
 
     @Test


### PR DESCRIPTION
Follow-up to #811, covering the review points that were left out of it so that PR did not need another round.

## README

**The `codeartifact()` helper was documented as unavailable in `settings.gradle(.kts)` in three places** — the note under "Explicit `codeartifact` method", the note under "Settings configuration", and a new note added by #811. Verified false against the merged code: it works inside `dependencyResolutionManagement` in both DSLs (Kotlin needs `import ai.clarity.codeartifact.codeartifact`, Groovy needs nothing). It fails only inside `pluginManagement`, which Gradle evaluates before `plugins { }` applies the plugin. All three notes now say exactly that.

**The credentials resolution order presented one list as if it applied uniformly.** Steps 4 and 5 (`codeartifact.profile`, `CODEARTIFACT_PROFILE`) never reach a repository declared with the helper — with `CODEARTIFACT_PROFILE=dev` set, `codeartifact(url)` still logs `in profile default`. Adds a note, plus one saying the incomplete-credentials check is skipped when a repository-level profile already settled the authentication.

## AGENTS.md and docs/ONBOARDING.md

Both predate #811 and had gone stale. Updated: the behaviour contract, the architecture diagram and entry-point tables, the resolution table (now with the service-credential step and the two asymmetries), a new secret-handling subsection, the gotchas table, and the test counts (115 → 171).

## Code

`SUPPORTED_KEYS` was a `Set.of`, whose iteration order varies between JVM runs, and it is rendered in the `Unsupported CodeArtifact credentials [...], expected any of [...]` message. A `LinkedHashSet` keeps it stable; the test now pins the full message rather than a substring.

## CI

`build.yml` only triggered `on: [push]`, so **a pull request from a fork was never built**. #811 came from a fork and merged with zero checks — its correctness rested on a local run. Adds a `pull_request` trigger and narrows the push trigger to `main`, so a PR is built exactly once whatever repository it comes from.

## Verification

`./gradlew build --rerun-tasks`: 86 unit + 85 functional tests, all green. The `Java CI` run for the #811 merge commit on `main` also passed, which retroactively confirms the merged feature.

## Left for later

Two review points not addressed here, both non-blocking:

- Some new tests depend on the ambient environment: `ServiceCredentialsFunctionalTest."incomplete service credentials fail with a descriptive error"` runs without `.withEnvironment(...)`, and the new unit tests use `System.setProperty` while the resolver falls back to `System.getenv`, so an ambient `CODEARTIFACT_*` variable can change the outcome.
- The resolver reads `System.getProperty`/`getenv` directly at configuration time, so the values are untracked inputs. Pre-existing pattern, and the configuration cache is not enabled here, but `ProviderFactory` would be the forward-looking choice.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
