### PR TITLE
chore: broaden the plugin description and tags for the Plugin Portal

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -39,18 +39,27 @@ dependencies {
   testRuntimeOnly(libs.junit.platform.launcher)
 }
 
+// Shown on the Gradle Plugin Portal. The portal keeps the description it recorded at the first
+// publication, so a change here does not reach the published page on its own: it also needs a
+// request at https://github.com/gradle/plugin-portal-requests
+val pluginDescription = "Easily use private AWS CodeArtifact repositories from Gradle - for dependencies, plugins and " +
+  "publishing. Just apply the plugin: it detects the CodeArtifact repositories declared in your build, including " +
+  "those in pluginManagement and dependencyResolutionManagement, and injects the authorization token for you, with " +
+  "no extra configuration. Authenticates through an AWS profile, the static access keys of a service account, SSO, " +
+  "or the default AWS credential chain."
+
 gradlePlugin {
   // Define the plugin
   website = "https://github.com/clarityai-eng/codeartifact-gradle-plugin"
   vcsUrl = "https://github.com/clarityai-eng/codeartifact-gradle-plugin"
-  description = "Gradle plugin to login easily to AWS CodeArtifact"
+  description = pluginDescription
   plugins {
     register("clarityCodeartifact") {
       id = "ai.clarity.codeartifact"
       implementationClass = "ai.clarity.codeartifact.ClarityCodeArtifactGradlePlugin"
       displayName = "Clarity CodeArtifact Plugin"
-      description = "Gradle plugin to login easily to AWS CodeArtifact"
-      tags = listOf("aws", "codeartifact")
+      description = pluginDescription
+      tags = listOf("aws", "codeartifact", "maven", "authentication", "credentials", "publishing")
     }
   }
 }


### PR DESCRIPTION
Broadens the Gradle Plugin Portal metadata.

## Description

The declared description still framed the plugin as a login helper:

> Gradle plugin to login easily to AWS CodeArtifact

It now says what the plugin actually covers — dependency resolution, plugin resolution and
publishing — and that it can authenticate four different ways:

> Easily use private AWS CodeArtifact repositories from Gradle - for dependencies, plugins and
> publishing. Just apply the plugin: it detects the CodeArtifact repositories declared in your
> build, including those in `pluginManagement` and `dependencyResolutionManagement`, and injects
> the authorization token for you, with no extra configuration. Authenticates through an AWS
> profile, the static access keys of a service account, SSO, or the default AWS credential chain.

The text is now a single `val` feeding both the project-level and the per-plugin `description`,
which had drifted into two copies of the same literal.

## Tags

`aws`, `codeartifact` → `aws`, `codeartifact`, `maven`, `authentication`, `credentials`, `publishing`.

## Why this alone is not enough

Worth knowing, and recorded as a comment in the build file: **the Plugin Portal keeps the
description recorded at the first publication, and later publishes do not update it.** The portal
page for 0.2.0, published today, still renders the 0.0.12 string `Login easily to aws codeartifact`
— the change made back in 0.1.1 has never taken effect.

So this PR keeps the repository honest, but the published page only changes through a request at
[gradle/plugin-portal-requests](https://github.com/gradle/plugin-portal-requests) (the portal's own
"Report incorrect plugin description" button points at its `Plugin Description Update` template).
Filed separately.

No functional change; `./gradlew validatePlugins` passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
