### PR TITLE
feat: accept the codeartifact.* settings as plain Gradle properties

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -34,8 +34,8 @@ All verified on this checkout (`main`, 2026-09-01).
 
 ```bash
 ./gradlew build            # compile + unit tests + functionalTest + validatePlugins
-./gradlew test             # 86 unit tests
-./gradlew functionalTest   # 85 TestKit tests across Gradle 8.4, 8.7, 8.14, 9.1.0, 9.4.0
+./gradlew test             # 98 unit tests
+./gradlew functionalTest   # 101 TestKit tests across Gradle 8.4, 8.7, 8.14, 9.1.0, 9.4.0
 ./gradlew publishToMavenLocal   # for trying the plugin from a scratch project
 ./gradlew tasks --all
 ```
@@ -64,7 +64,9 @@ src/main/kotlin/ai/clarity/codeartifact/
   CodeArtifactSettingsPlugin.kt        # Settings target: pluginManagement + DRM repositories
   CodeartifactRepositoryConfigurer.kt  # shared logic: detect, resolve profile, inject creds
   CodeArtifactAuthenticator.kt         # picks credentials vs profile for one repository
-  CodeArtifactCredentialsResolver.kt   # build-wide service credentials from sysprops/env
+  CodeArtifactCredentialsResolver.kt   # build-wide service credentials, read via SettingLookup
+  SettingLookup.kt                     # one codeartifact.* setting from Gradle property /
+                                       #   system property / env, plus the shadowing warning
 src/main/java/ai/clarity/codeartifact/
   CodeArtifactToken.java               # Gradle BuildService, caches tokens per auth+url
   CodeArtifactCredentials.java         # static service-account keys: masking, redaction, cache key
@@ -103,11 +105,15 @@ experiments):
 3. `?profile=<name>` is read from the URL and then **stripped** from the final repository URL.
 4. Credentials precedence, closest-to-the-repository first: credentials passed to
    `codeartifact()` → `?profile=` or a profile passed to `codeartifact()` →
-   `codeartifact.accessKeyId`/`secretAccessKey` (system property, then `CODEARTIFACT_*` env) →
-   `-Dcodeartifact.profile` / `systemProp.codeartifact.profile` → `CODEARTIFACT_PROFILE` →
-   *null* (AWS default chain, which honours `AWS_PROFILE`). The last two steps apply to
+   `codeartifact.accessKeyId`/`secretAccessKey` → `codeartifact.profile` → *null* (AWS default
+   chain, which honours `AWS_PROFILE`). The `codeartifact.profile` step applies to
    automatically detected repositories only; the `codeartifact()` helper falls back to the
    `default` profile instead.
+   Every `codeartifact.*` setting is read by `SettingLookup` from three sources in order:
+   Gradle property (plain `gradle.properties` entry or `-P`) → system property (`systemProp.`
+   or `-D`) → `CODEARTIFACT_*` environment variable. The first source that holds the setting
+   wins even when blank, and a blank value resolves to `null`. A Gradle property shadowing a
+   differently-valued system property logs a warning, once per setting.
 5. Tokens are fetched **once per authentication + url** and shared through a Gradle
    `BuildService`. Profile entries and service-credential entries never share a cache slot, and
    the credentials half of the key is a SHA-256 digest so no secret is held in clear.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -34,8 +34,8 @@ All verified on this checkout (`main`, 2026-09-01).
 
 ```bash
 ./gradlew build            # compile + unit tests + functionalTest + validatePlugins
-./gradlew test             # 98 unit tests
-./gradlew functionalTest   # 101 TestKit tests across Gradle 8.4, 8.7, 8.14, 9.1.0, 9.4.0
+./gradlew test             # 102 unit tests
+./gradlew functionalTest   # 106 TestKit tests across Gradle 8.4, 8.7, 8.14, 9.1.0, 9.4.0
 ./gradlew publishToMavenLocal   # for trying the plugin from a scratch project
 ./gradlew tasks --all
 ```
@@ -113,7 +113,8 @@ experiments):
    Gradle property (plain `gradle.properties` entry or `-P`) → system property (`systemProp.`
    or `-D`) → `CODEARTIFACT_*` environment variable. The first source that holds the setting
    wins even when blank, and a blank value resolves to `null`. A Gradle property shadowing a
-   differently-valued system property logs a warning, once per setting.
+   differently-valued system property — or, when no system property is set, a differently-valued
+   environment variable — logs a warning, once per setting.
 5. Tokens are fetched **once per authentication + url** and shared through a Gradle
    `BuildService`. Profile entries and service-credential entries never share a cache slot, and
    the credentials half of the key is a SHA-256 digest so no secret is held in clear.

--- a/README.md
+++ b/README.md
@@ -318,7 +318,9 @@ Keep in mind:
   a committed plain `codeartifact.profile` is ignored — the build warns when that happens
   rather than authenticating with the wrong profile silently.
 - Neither `CODEARTIFACT_PROFILE` nor any other environment variable takes precedence over a
-  profile defined in `gradle.properties`.
+  profile defined in `gradle.properties`. When a plain entry shadows a differently-valued
+  `CODEARTIFACT_PROFILE`, the build warns, since that usually means an exported override has
+  stopped working.
 - A developer can override the project default for their machine in
   `~/.gradle/gradle.properties`, which takes precedence over the project file.
 - Do not combine this pattern with `?profile=` in the repository URL: the query param has
@@ -426,8 +428,9 @@ Every `codeartifact.*` setting in steps 3 and 4 is looked up in three places, in
 3. the **environment variable** — `CODEARTIFACT_PROFILE`, `CODEARTIFACT_ACCESS_KEY_ID`, …
 
 The first place that holds the setting wins, even when the value is blank; a blank value then resolves to "not
-configured" rather than falling through to the next place. When a Gradle property shadows a system property holding a
-different value, the build warns, because that is usually a `-D` override that has stopped working.
+configured" rather than falling through to the next place. When a Gradle property shadows a system property — or, with
+no system property set, an environment variable — holding a different value, the build warns, because that is usually a
+`-D` or exported override that has stopped working.
 
 > **Note:** step 4 only applies to the repositories detected automatically. A repository declared with the
 > `codeartifact()` helper and no explicit profile falls back to the `default` profile instead, so `codeartifact.profile`

--- a/README.md
+++ b/README.md
@@ -272,22 +272,26 @@ the [standard environment variables](https://docs.aws.amazon.com/sdk-for-java/v1
 If you need a different profile for CodeArtifact than for the rest of your AWS calls you can use this environment
 variable.
 
-### 4 – Define the profile using a system property
+### 4 – Define the profile using a Gradle property
 
 If you need a different profile for CodeArtifact and you cannot define an environment variable, you
-can define it via a system property.
+can define it as a Gradle property.
 
 Using the `gradle.properties` file:
 
 ```properties
-systemProp.codeartifact.profile=<your profile>
+codeartifact.profile=<your profile>
 ```
 
 Or using the command line:
 
 ```bash
-gradle -Dcodeartifact.profile=<your profile> ...
+gradle -Pcodeartifact.profile=<your profile> ...
 ```
+
+The system property form is equally supported, for builds that already use it:
+`systemProp.codeartifact.profile=<your profile>` in `gradle.properties`, or
+`-Dcodeartifact.profile=<your profile>` on the command line.
 
 ### Recommended pattern: project-wide default profile with CI/CD override
 
@@ -297,22 +301,24 @@ override it, commit the default to the project's `gradle.properties` instead of 
 
 ```properties
 # gradle.properties (committed with the project)
-systemProp.codeartifact.profile=dev
+codeartifact.profile=dev
 ```
 
 Local builds then use the `dev` profile out of the box, and CI/CD overrides it from the
 command line:
 
 ```bash
-gradle -Dcodeartifact.profile=ci ...
+gradle -Pcodeartifact.profile=ci ...
 ```
 
 Keep in mind:
 
-- The `systemProp.` prefix is required. A plain `codeartifact.profile=dev` entry defines a
-  Gradle project property, which the plugin does not read.
-- Override with `-D` on the command line. The `CODEARTIFACT_PROFILE` environment variable
-  does not take precedence over a system property defined in `gradle.properties`.
+- **Match the override to the form you committed.** A Gradle property is overridden with `-P`,
+  a `systemProp.` one with `-D`. Since the Gradle property is the one that wins, a `-D` against
+  a committed plain `codeartifact.profile` is ignored — the build warns when that happens
+  rather than authenticating with the wrong profile silently.
+- Neither `CODEARTIFACT_PROFILE` nor any other environment variable takes precedence over a
+  profile defined in `gradle.properties`.
 - A developer can override the project default for their machine in
   `~/.gradle/gradle.properties`, which takes precedence over the project file.
 - Do not combine this pattern with `?profile=` in the repository URL: the query param has
@@ -325,10 +331,10 @@ keys of a service account — an IAM user or a set of temporary credentials — 
 
 ### For the whole build
 
-Configure the access key id and the secret access key. Each value is read from its system property first, and from its
-environment variable second:
+Configure the access key id and the secret access key. Each value is read from its Gradle property first, from the
+system property of the same name second, and from its environment variable last:
 
-| Value             | System property                | Environment variable             | Required                       |
+| Value             | Gradle / system property       | Environment variable             | Required                       |
 |-------------------|--------------------------------|----------------------------------|--------------------------------|
 | Access key id     | `codeartifact.accessKeyId`     | `CODEARTIFACT_ACCESS_KEY_ID`     | Yes                            |
 | Secret access key | `codeartifact.secretAccessKey` | `CODEARTIFACT_SECRET_ACCESS_KEY` | Yes                            |
@@ -344,9 +350,11 @@ export CODEARTIFACT_SECRET_ACCESS_KEY=<your secret access key>
 On a developer machine, declare them in `~/.gradle/gradle.properties`, which lives outside the project:
 
 ```properties
-systemProp.codeartifact.accessKeyId=<your access key id>
-systemProp.codeartifact.secretAccessKey=<your secret access key>
+codeartifact.accessKeyId=<your access key id>
+codeartifact.secretAccessKey=<your secret access key>
 ```
+
+The `systemProp.codeartifact.accessKeyId` form works too, for builds that already use it.
 
 They then apply to every CodeArtifact repository of the build, including the ones declared in `settings.gradle(.kts)`,
 and they take precedence over the `codeartifact.profile` / `CODEARTIFACT_PROFILE` configuration.
@@ -407,15 +415,23 @@ the same level:
 
 1. Credentials passed to the `codeartifact()` helper
 2. Profile passed to the `codeartifact()` helper, or `?profile=` query parameter in the repository URL
-3. `codeartifact.accessKeyId` and `codeartifact.secretAccessKey`, each read from the system property first and from the
-   matching `CODEARTIFACT_*` environment variable second
-4. `codeartifact.profile` Java system property
-5. `CODEARTIFACT_PROFILE` environment variable
-6. The AWS SDK default credentials provider chain (`AWS_PROFILE`, `AWS_ACCESS_KEY_ID`, instance roles, …)
+3. `codeartifact.accessKeyId` and `codeartifact.secretAccessKey`
+4. `codeartifact.profile`
+5. The AWS SDK default credentials provider chain (`AWS_PROFILE`, `AWS_ACCESS_KEY_ID`, instance roles, …)
 
-> **Note:** steps 4 and 5 only apply to the repositories detected automatically. A repository declared with the
+Every `codeartifact.*` setting in steps 3 and 4 is looked up in three places, in this order:
+
+1. the **Gradle property** — written plainly in `gradle.properties`, or passed as `-P`
+2. the **Java system property** — written as `systemProp.` in `gradle.properties`, or passed as `-D`
+3. the **environment variable** — `CODEARTIFACT_PROFILE`, `CODEARTIFACT_ACCESS_KEY_ID`, …
+
+The first place that holds the setting wins, even when the value is blank; a blank value then resolves to "not
+configured" rather than falling through to the next place. When a Gradle property shadows a system property holding a
+different value, the build warns, because that is usually a `-D` override that has stopped working.
+
+> **Note:** step 4 only applies to the repositories detected automatically. A repository declared with the
 > `codeartifact()` helper and no explicit profile falls back to the `default` profile instead, so `codeartifact.profile`
-> and `CODEARTIFACT_PROFILE` have no effect on it. Pass the profile to the helper if you need another one.
+> has no effect on it. Pass the profile to the helper if you need another one.
 
 The incomplete-configuration check on step 3 runs only when steps 1 and 2 did not already settle the authentication:
 with a `?profile=` in the URL, or a profile passed to the helper, a half-configured pair of service credentials is

--- a/docs/ONBOARDING.md
+++ b/docs/ONBOARDING.md
@@ -213,9 +213,11 @@ Two asymmetries worth knowing, both measured:
 **Match the command-line override to the form you committed.** A Gradle property is overridden
 with `-P`, a `systemProp.` one with `-D`. Because the Gradle property outranks the system
 property, a `-Dcodeartifact.profile=ci` against a committed plain `codeartifact.profile=dev` does
-*not* override it. That combination logs a warning naming the setting rather than silently
-authenticating with the wrong profile — the values are deliberately left out of the message so a
-shadowed `codeartifact.secretAccessKey` cannot leak.
+*not* override it. The same goes for the environment variable when no system property is set: a
+`CODEARTIFACT_PROFILE` export loses to a plain `codeartifact.profile` entry. Both combinations log
+a warning naming the setting rather than silently authenticating with the wrong profile — the
+values are deliberately left out of the message so a shadowed `codeartifact.secretAccessKey` (or
+`CODEARTIFACT_SECRET_ACCESS_KEY`) cannot leak.
 
 Recommended pattern for teams: commit `codeartifact.profile=dev` and let CI override with
 `-Pcodeartifact.profile=ci`. Do not mix it with `?profile=`, which would defeat the override.
@@ -237,8 +239,8 @@ reaches build scans, caches and logs. What the plugin does guarantee, all verifi
 ## 6. Testing
 
 ```bash
-./gradlew test --rerun-tasks            # 98 tests, all green
-./gradlew functionalTest --rerun-tasks  # 101 tests, all green
+./gradlew test --rerun-tasks            # 102 tests, all green
+./gradlew functionalTest --rerun-tasks  # 106 tests, all green
 ./gradlew build                         # both + validatePlugins; ~4m from clean
 ```
 
@@ -309,7 +311,8 @@ Never run `release` or `publishPlugins` from an agent session — both are outwa
 | Wrong profile used by `codeartifact(url)` | With no profile it falls back to `"default"`; `codeartifact.profile` is ignored on that path, though build-wide service credentials are honoured. |
 | `Incomplete CodeArtifact service credentials: …` | Exactly one of `codeartifact.accessKeyId` / `codeartifact.secretAccessKey` is set, in any of the three sources. Set both, or unset both. |
 | `The codeartifact.X Gradle property takes precedence over the codeartifact.X system property` | A plain `gradle.properties` entry is shadowing a `-D` / `systemProp.` value. Override with `-P` instead, or drop the plain entry. |
-| A `-D` override stopped working after upgrading the plugin | Same cause as the row above: the plain Gradle property form is now read, and it outranks the system property. |
+| `The codeartifact.X Gradle property takes precedence over the CODEARTIFACT_X environment variable` | A plain `gradle.properties` entry is shadowing an exported environment variable. Override with `-P` instead, or drop the plain entry. |
+| A `-D` override or a `CODEARTIFACT_*` export stopped working after upgrading the plugin | Same cause as the rows above: the plain Gradle property form is now read, and it outranks both. |
 | `Timeout waiting to lock journal cache` | Gradle running inside the Claude Code sandbox. Disable the sandbox. |
 | Credentials not injected on a CodeArtifact URL | The repository already had a username or password; the plugin skips those. |
 

--- a/docs/ONBOARDING.md
+++ b/docs/ONBOARDING.md
@@ -183,27 +183,42 @@ build-wide:
 |---|---|---|
 | 1 | `CodeArtifactCredentials` passed to `codeartifact()` (Kotlin) or a credentials map (Groovy) | wins over everything |
 | 2 | `?profile=<name>` in the URL, or a profile passed to `codeartifact()` | beats every build-wide setting; the query param is stripped from the final URL |
-| 3 | `codeartifact.accessKeyId` + `codeartifact.secretAccessKey` (`systemProp.`/`-D`), else `CODEARTIFACT_ACCESS_KEY_ID` + `CODEARTIFACT_SECRET_ACCESS_KEY` | static service-account keys; optional `codeartifact.sessionToken` / `CODEARTIFACT_SESSION_TOKEN` for temporary ones |
-| 4 | `-Dcodeartifact.profile=<name>` / `systemProp.codeartifact.profile=<name>` | command line overrides the properties file |
-| 5 | `CODEARTIFACT_PROFILE` env var | used when 1-4 are absent |
-| 6 | nothing → profile is `null` | the AWS SDK default chain runs, so `AWS_PROFILE`, `AWS_ACCESS_KEY_ID`, SSO caches and instance roles apply |
+| 3 | `codeartifact.accessKeyId` + `codeartifact.secretAccessKey` | static service-account keys; optional `codeartifact.sessionToken` for temporary ones |
+| 4 | `codeartifact.profile` | the build-wide default profile |
+| 5 | nothing → profile is `null` | the AWS SDK default chain runs, so `AWS_PROFILE`, `AWS_ACCESS_KEY_ID`, SSO caches and instance roles apply |
+
+Each `codeartifact.*` setting in steps 3 and 4 is resolved by `SettingLookup` from three sources,
+highest precedence first:
+
+| # | Source | Written as |
+|---|---|---|
+| 1 | Gradle property | a plain `codeartifact.profile=<name>` in `gradle.properties`, or `-Pcodeartifact.profile=<name>` |
+| 2 | Java system property | `systemProp.codeartifact.profile=<name>` in `gradle.properties`, or `-Dcodeartifact.profile=<name>` |
+| 3 | environment variable | `CODEARTIFACT_PROFILE`, `CODEARTIFACT_ACCESS_KEY_ID`, `CODEARTIFACT_SECRET_ACCESS_KEY`, `CODEARTIFACT_SESSION_TOKEN` |
+
+The first source that *holds* the setting wins, even when the value is blank; a blank value then
+resolves to "not configured" rather than falling through. Verified on Gradle 8.4 through 9.7.1,
+in `Settings` scripts as well as project ones.
 
 Two asymmetries worth knowing, both measured:
 
-- **Steps 4 and 5 apply to automatic detection only.** A repository declared with
+- **Step 4 applies to automatic detection only.** A repository declared with
   `codeartifact()` and no explicit profile falls back to the `default` profile instead, so
-  `codeartifact.profile` and `CODEARTIFACT_PROFILE` have no effect on it. Step 3 *does* reach it.
+  `codeartifact.profile` has no effect on it. Step 3 *does* reach it.
 - **Setting exactly one of the two required step-3 values fails the build** with
   `Incomplete CodeArtifact service credentials: …`, naming the missing half — but only when
   steps 1 and 2 did not already settle the authentication. With a `?profile=` in the URL the
   half-configured pair is ignored instead of reported.
 
-`codeartifact.profile` must carry the `systemProp.` prefix in `gradle.properties`; a plain
-`codeartifact.profile=dev` becomes a Gradle project property, which the plugin never reads. The
-same applies to `codeartifact.accessKeyId` and `codeartifact.secretAccessKey`.
+**Match the command-line override to the form you committed.** A Gradle property is overridden
+with `-P`, a `systemProp.` one with `-D`. Because the Gradle property outranks the system
+property, a `-Dcodeartifact.profile=ci` against a committed plain `codeartifact.profile=dev` does
+*not* override it. That combination logs a warning naming the setting rather than silently
+authenticating with the wrong profile — the values are deliberately left out of the message so a
+shadowed `codeartifact.secretAccessKey` cannot leak.
 
-Recommended pattern for teams: commit `systemProp.codeartifact.profile=dev` and let CI override
-with `-Dcodeartifact.profile=ci`. Do not mix it with `?profile=`, which would defeat the override.
+Recommended pattern for teams: commit `codeartifact.profile=dev` and let CI override with
+`-Pcodeartifact.profile=ci`. Do not mix it with `?profile=`, which would defeat the override.
 CI that has no `~/.aws/credentials` at all should export the `CODEARTIFACT_*` keys instead.
 
 ### Secret handling
@@ -222,8 +237,8 @@ reaches build scans, caches and logs. What the plugin does guarantee, all verifi
 ## 6. Testing
 
 ```bash
-./gradlew test --rerun-tasks            # 86 tests, all green
-./gradlew functionalTest --rerun-tasks  # 85 tests, all green
+./gradlew test --rerun-tasks            # 98 tests, all green
+./gradlew functionalTest --rerun-tasks  # 101 tests, all green
 ./gradlew build                         # both + validatePlugins; ~4m from clean
 ```
 
@@ -291,8 +306,10 @@ Never run `release` or `publishPlugins` from an agent session — both are outwa
 | `Not a valid CodeArtifact repository URL: …` | Host does not match `{domain}-{owner}.d.codeartifact.{region}.…` — e.g. a missing `-{owner}`, or a VPC endpoint. Fails the build by design. |
 | `Unresolved reference 'codeartifact'` | Missing `import ai.clarity.codeartifact.codeartifact` in a `.kts` file (`CodeArtifactCredentials` needs its own import). |
 | `Could not find method codeartifact()` inside `pluginManagement` | The block runs before the plugin is applied. Use `maven { url = … }` there. |
-| Wrong profile used by `codeartifact(url)` | With no profile it falls back to `"default"`; `codeartifact.profile` and `CODEARTIFACT_PROFILE` are ignored on that path, though build-wide service credentials are honoured. |
-| `Incomplete CodeArtifact service credentials: …` | Exactly one of `codeartifact.accessKeyId` / `codeartifact.secretAccessKey` (or their `CODEARTIFACT_*` env equivalents) is set. Set both, or unset both. |
+| Wrong profile used by `codeartifact(url)` | With no profile it falls back to `"default"`; `codeartifact.profile` is ignored on that path, though build-wide service credentials are honoured. |
+| `Incomplete CodeArtifact service credentials: …` | Exactly one of `codeartifact.accessKeyId` / `codeartifact.secretAccessKey` is set, in any of the three sources. Set both, or unset both. |
+| `The codeartifact.X Gradle property takes precedence over the codeartifact.X system property` | A plain `gradle.properties` entry is shadowing a `-D` / `systemProp.` value. Override with `-P` instead, or drop the plain entry. |
+| A `-D` override stopped working after upgrading the plugin | Same cause as the row above: the plain Gradle property form is now read, and it outranks the system property. |
 | `Timeout waiting to lock journal cache` | Gradle running inside the Claude Code sandbox. Disable the sandbox. |
 | Credentials not injected on a CodeArtifact URL | The repository already had a username or password; the plugin skips those. |
 

--- a/src/functionalTest/kotlin/ai/clarity/codeartifact/ClarityCodeArtifactGradlePluginFunctionalTest.kt
+++ b/src/functionalTest/kotlin/ai/clarity/codeartifact/ClarityCodeArtifactGradlePluginFunctionalTest.kt
@@ -580,6 +580,26 @@ class ClarityCodeartifactPluginFunctionalTest {
 
     @ParameterizedTest(name = "Gradle {0}")
     @MethodSource("ai.clarity.codeartifact.ClarityCodeartifactPluginFunctionalTest#gradleVersions")
+    fun `a plain gradle property shadows the environment variable and says so`(gradleVersion: String) {
+      // Given: a plain default in gradle.properties and a CODEARTIFACT_PROFILE that used to win before the plain form was read
+      gradlePropertiesFile.writeText("codeartifact.profile=dev")
+
+      // When: running the build with the environment variable pointing elsewhere
+      val result = createRunner(gradleVersion)
+        .withEnvironment(System.getenv() + ("CODEARTIFACT_PROFILE" to "ci"))
+        .withArguments("help", "--info")
+        .buildAndFail()
+
+      // Then: the Gradle property wins, and the build warns that the environment variable is being ignored
+      assertThat(result.output).containsIgnoringCase("Getting token for $codeArtifactUrl in profile dev")
+      assertThat(result.output).contains(
+        "The codeartifact.profile Gradle property takes precedence over the CODEARTIFACT_PROFILE environment variable"
+      )
+      assertThat(result.output).contains("Override the Gradle property with -Pcodeartifact.profile")
+    }
+
+    @ParameterizedTest(name = "Gradle {0}")
+    @MethodSource("ai.clarity.codeartifact.ClarityCodeartifactPluginFunctionalTest#gradleVersions")
     fun `command line system property overrides the gradle properties default`(gradleVersion: String) {
       // Given: a project-wide default profile and a CI-style command line override
       gradlePropertiesFile.writeText("systemProp.codeartifact.profile=dev")

--- a/src/functionalTest/kotlin/ai/clarity/codeartifact/ClarityCodeArtifactGradlePluginFunctionalTest.kt
+++ b/src/functionalTest/kotlin/ai/clarity/codeartifact/ClarityCodeArtifactGradlePluginFunctionalTest.kt
@@ -531,6 +531,55 @@ class ClarityCodeartifactPluginFunctionalTest {
 
     @ParameterizedTest(name = "Gradle {0}")
     @MethodSource("ai.clarity.codeartifact.ClarityCodeartifactPluginFunctionalTest#gradleVersions")
+    fun `profile default from a plain gradle property is used`(gradleVersion: String) {
+      // Given: the default profile written without the systemProp. prefix, the way a Gradle plugin is usually configured
+      gradlePropertiesFile.writeText("codeartifact.profile=dev")
+
+      // When: running the build (expecting a failure due to missing AWS credentials)
+      val result = createRunner(gradleVersion)
+        .withArguments("help", "--info")
+        .buildAndFail()
+
+      // Then: the token fetch uses the project default profile
+      assertThat(result.output).containsIgnoringCase("Getting token for $codeArtifactUrl in profile dev")
+    }
+
+    @ParameterizedTest(name = "Gradle {0}")
+    @MethodSource("ai.clarity.codeartifact.ClarityCodeartifactPluginFunctionalTest#gradleVersions")
+    fun `command line project property overrides the plain gradle properties default`(gradleVersion: String) {
+      // Given: a project-wide default profile written plainly
+      gradlePropertiesFile.writeText("codeartifact.profile=dev")
+
+      // When: running the build with -P, as a CI pipeline would
+      val result = createRunner(gradleVersion)
+        .withArguments("help", "--info", "-Pcodeartifact.profile=ci")
+        .buildAndFail()
+
+      // Then: the command line wins over the gradle.properties default
+      assertThat(result.output).containsIgnoringCase("Getting token for $codeArtifactUrl in profile ci")
+    }
+
+    @ParameterizedTest(name = "Gradle {0}")
+    @MethodSource("ai.clarity.codeartifact.ClarityCodeartifactPluginFunctionalTest#gradleVersions")
+    fun `a plain gradle property shadows the system property and says so`(gradleVersion: String) {
+      // Given: the same setting configured both ways, which is how a half-finished migration to the plain form looks
+      gradlePropertiesFile.writeText("codeartifact.profile=dev")
+
+      // When: the command line tries to override it with -D, which no longer reaches the plugin
+      val result = createRunner(gradleVersion)
+        .withArguments("help", "--info", "-Dcodeartifact.profile=ci")
+        .buildAndFail()
+
+      // Then: the Gradle property wins, and the build warns that the -D override is being ignored
+      assertThat(result.output).containsIgnoringCase("Getting token for $codeArtifactUrl in profile dev")
+      assertThat(result.output).contains(
+        "The codeartifact.profile Gradle property takes precedence over the codeartifact.profile system property"
+      )
+      assertThat(result.output).contains("Override the Gradle property with -Pcodeartifact.profile")
+    }
+
+    @ParameterizedTest(name = "Gradle {0}")
+    @MethodSource("ai.clarity.codeartifact.ClarityCodeartifactPluginFunctionalTest#gradleVersions")
     fun `command line system property overrides the gradle properties default`(gradleVersion: String) {
       // Given: a project-wide default profile and a CI-style command line override
       gradlePropertiesFile.writeText("systemProp.codeartifact.profile=dev")
@@ -708,6 +757,31 @@ class ClarityCodeartifactPluginFunctionalTest {
     }
 
     @Test
+    fun `service credentials from plain gradle properties are used to fetch the token`() {
+      // Given: the service account credentials declared without the systemProp. prefix
+      buildFile.writeText(printRepoCredentialsBuild(codeArtifactUrl))
+      gradlePropertiesFile.writeText(
+        """
+        codeartifact.accessKeyId=$serviceUserAccessKeyId
+        codeartifact.secretAccessKey=service-user-secret
+        """.trimIndent()
+      )
+
+      // When: running the build with no AWS credentials in the environment
+      val result = runnerWithoutAwsCredentials()
+        .withEnvironment(
+          environmentWithoutAwsCredentials("AWS_ENDPOINT_URL_CODEARTIFACT" to "http://127.0.0.1:${server.address.port}")
+        )
+        .withArguments("printRepoCredentials", "--info")
+        .build()
+
+      // Then: the repository ends up configured with the token issued for the service account
+      assertThat(result.output).contains("with the service credentials $maskedServiceUserAccessKeyId")
+      assertThat(result.output).doesNotContain("service-user-secret")
+      assertThat(result.output).contains("password=stub-token")
+    }
+
+    @Test
     fun `a repository profile keeps precedence over the service credentials of the build`() {
       // Given: service credentials for the whole build and an explicit profile on the repository
       buildFile.writeText(printRepoCredentialsBuild("$codeArtifactUrl?profile=url-profile"))
@@ -742,9 +816,10 @@ class ClarityCodeartifactPluginFunctionalTest {
         .withArguments("printRepoCredentials")
         .buildAndFail()
 
-      // Then: the build explains which half is missing
+      // Then: the build explains which half is missing, naming every source it could be set in
       assertThat(result.output).contains("Incomplete CodeArtifact service credentials")
-      assertThat(result.output).contains("codeartifact.secretAccessKey")
+      assertThat(result.output).contains("codeartifact.secretAccessKey Gradle property")
+      assertThat(result.output).contains("codeartifact.secretAccessKey system property")
       assertThat(result.output).contains("CODEARTIFACT_SECRET_ACCESS_KEY")
     }
 

--- a/src/main/kotlin/ai/clarity/codeartifact/ClarityCodeArtifactGradlePlugin.kt
+++ b/src/main/kotlin/ai/clarity/codeartifact/ClarityCodeArtifactGradlePlugin.kt
@@ -80,8 +80,9 @@ private fun RepositoryHandler.codeartifactRepository(
 
   @Suppress("UNCHECKED_CAST")
   val serviceProvider = ext["codeartifactServiceProvider"] as Provider<CodeArtifactToken>
+  val settings = ext["codeartifactSettingLookup"] as SettingLookup
   val token = CodeArtifactAuthenticator.getToken(
-    serviceProvider.get(), logger, repoUrl, credentials, profile, DEFAULT_PROFILE
+    serviceProvider.get(), logger, settings, repoUrl, credentials, profile, DEFAULT_PROFILE
   )
   maven { mavenRepo ->
     mavenRepo.url = URI(repoUrl)

--- a/src/main/kotlin/ai/clarity/codeartifact/CodeArtifactAuthenticator.kt
+++ b/src/main/kotlin/ai/clarity/codeartifact/CodeArtifactAuthenticator.kt
@@ -32,18 +32,20 @@ internal object CodeArtifactAuthenticator {
    *
    *  1. [credentials] declared on the repository itself
    *  2. [profile] declared on the repository itself
-   *  3. the service account credentials shared by the build ([CodeArtifactCredentialsResolver])
+   *  3. the service account credentials shared by the build, read from [settings] by
+   *     [CodeArtifactCredentialsResolver]
    *  4. [fallbackProfile], which may be `null` to let the AWS SDK resolve the credentials on its own
    */
   fun getToken(
     tokenService: CodeArtifactToken,
     logger: Logger,
+    settings: SettingLookup,
     repoUrl: String,
     credentials: CodeArtifactCredentials? = null,
     profile: String? = null,
     fallbackProfile: String? = null
   ): String {
-    val serviceCredentials = credentials ?: if (profile == null) CodeArtifactCredentialsResolver.resolve() else null
+    val serviceCredentials = credentials ?: if (profile == null) CodeArtifactCredentialsResolver.resolve(settings) else null
     if (serviceCredentials != null) {
       logger.info("Getting token for {} with the service credentials {}", repoUrl, serviceCredentials.maskedAccessKeyId)
       return tokenService.getToken(repoUrl, serviceCredentials)

--- a/src/main/kotlin/ai/clarity/codeartifact/CodeArtifactCredentialsResolver.kt
+++ b/src/main/kotlin/ai/clarity/codeartifact/CodeArtifactCredentialsResolver.kt
@@ -20,8 +20,7 @@ package ai.clarity.codeartifact
 import org.gradle.api.InvalidUserDataException
 
 /**
- * Resolves the service account credentials shared by the whole build, from system properties first and environment
- * variables second.
+ * Resolves the service account credentials shared by the whole build, from the sources a [SettingLookup] covers.
  *
  * They are deliberately not read from the repository URL: a query param would leak the secret access key into build
  * scans, caches and logs.
@@ -33,17 +32,12 @@ internal object CodeArtifactCredentialsResolver {
   private val SESSION_TOKEN = Source("codeartifact.sessionToken", "CODEARTIFACT_SESSION_TOKEN")
 
   /**
-   * Returns the configured credentials, or `null` when none is configured and the profile based authentication has to
-   * be used instead.
-   *
-   * The lookups are parameters so that the tests can exercise the environment variables without mutating the JVM.
+   * Returns the credentials configured through [settings], or `null` when none is configured and the profile based
+   * authentication has to be used instead.
    */
-  fun resolve(
-    systemProperties: (String) -> String? = System::getProperty,
-    environment: (String) -> String? = System::getenv
-  ): CodeArtifactCredentials? {
-    val accessKeyId = ACCESS_KEY_ID.read(systemProperties, environment)
-    val secretAccessKey = SECRET_ACCESS_KEY.read(systemProperties, environment)
+  fun resolve(settings: SettingLookup): CodeArtifactCredentials? {
+    val accessKeyId = ACCESS_KEY_ID.read(settings)
+    val secretAccessKey = SECRET_ACCESS_KEY.read(settings)
 
     if (accessKeyId == null && secretAccessKey == null) {
       return null
@@ -55,18 +49,17 @@ internal object CodeArtifactCredentialsResolver {
       throw incompleteCredentials(SECRET_ACCESS_KEY)
     }
 
-    return CodeArtifactCredentials.of(accessKeyId, secretAccessKey, SESSION_TOKEN.read(systemProperties, environment))
+    return CodeArtifactCredentials.of(accessKeyId, secretAccessKey, SESSION_TOKEN.read(settings))
   }
 
   private fun incompleteCredentials(missing: Source) = InvalidUserDataException(
-    "Incomplete CodeArtifact service credentials: neither the ${missing.systemProperty} system property nor the " +
-      "${missing.environmentVariable} environment variable is set. Configure both the access key id and the secret " +
-      "access key, or unset them to authenticate with an AWS profile."
+    "Incomplete CodeArtifact service credentials: neither the ${missing.property} Gradle property, nor the " +
+      "${missing.property} system property, nor the ${missing.environmentVariable} environment variable is set. " +
+      "Configure both the access key id and the secret access key, or unset them to authenticate with an AWS profile."
   )
 
-  private data class Source(val systemProperty: String, val environmentVariable: String) {
+  private data class Source(val property: String, val environmentVariable: String) {
 
-    fun read(systemProperties: (String) -> String?, environment: (String) -> String?): String? =
-      (systemProperties(systemProperty) ?: environment(environmentVariable))?.takeIf { it.isNotBlank() }
+    fun read(settings: SettingLookup): String? = settings.read(property, environmentVariable)
   }
 }

--- a/src/main/kotlin/ai/clarity/codeartifact/CodeArtifactProjectPlugin.kt
+++ b/src/main/kotlin/ai/clarity/codeartifact/CodeArtifactProjectPlugin.kt
@@ -29,12 +29,14 @@ internal class CodeArtifactProjectPlugin : Plugin<Project> {
       CodeArtifactToken::class.java
     ) {}
 
-    CodeartifactRepositoryConfigurer.configure(project.repositories, project.logger, serviceProvider)
+    val settings = SettingLookup.of(project.providers, project.logger)
+
+    CodeartifactRepositoryConfigurer.configure(project.repositories, project.logger, serviceProvider, settings)
 
     project.plugins.withId("maven-publish") {
       val publishing = project.extensions.findByType(PublishingExtension::class.java)
       publishing?.repositories?.let {
-        CodeartifactRepositoryConfigurer.configure(it, project.logger, serviceProvider)
+        CodeartifactRepositoryConfigurer.configure(it, project.logger, serviceProvider, settings)
       }
     }
   }

--- a/src/main/kotlin/ai/clarity/codeartifact/CodeArtifactSettingsPlugin.kt
+++ b/src/main/kotlin/ai/clarity/codeartifact/CodeArtifactSettingsPlugin.kt
@@ -30,8 +30,11 @@ internal class CodeArtifactSettingsPlugin : Plugin<Settings> {
     ) {}
 
     val logger = Logging.getLogger(Settings::class.java)
+    val lookup = SettingLookup.of(settings.providers, logger)
 
-    CodeartifactRepositoryConfigurer.configure(settings.pluginManagement.repositories, logger, serviceProvider)
-    CodeartifactRepositoryConfigurer.configure(settings.dependencyResolutionManagement.repositories, logger, serviceProvider)
+    CodeartifactRepositoryConfigurer.configure(settings.pluginManagement.repositories, logger, serviceProvider, lookup)
+    CodeartifactRepositoryConfigurer.configure(
+      settings.dependencyResolutionManagement.repositories, logger, serviceProvider, lookup
+    )
   }
 }

--- a/src/main/kotlin/ai/clarity/codeartifact/CodeartifactRepositoryConfigurer.kt
+++ b/src/main/kotlin/ai/clarity/codeartifact/CodeartifactRepositoryConfigurer.kt
@@ -31,20 +31,23 @@ internal object CodeartifactRepositoryConfigurer {
   fun configure(
     repositories: RepositoryHandler,
     logger: Logger,
-    serviceProvider: Provider<CodeArtifactToken>
+    serviceProvider: Provider<CodeArtifactToken>,
+    settings: SettingLookup
   ) {
-    setupCodeArtifactRepositories(repositories, logger, serviceProvider)
-    configRepositories(repositories, logger, serviceProvider)
+    setupCodeArtifactRepositories(repositories, logger, serviceProvider, settings)
+    configRepositories(repositories, logger, serviceProvider, settings)
   }
 
   private fun setupCodeArtifactRepositories(
     repositories: RepositoryHandler,
     logger: Logger,
-    serviceProvider: Provider<CodeArtifactToken>
+    serviceProvider: Provider<CodeArtifactToken>,
+    settings: SettingLookup
   ) {
     val ext = (repositories as ExtensionAware).extensions.extraProperties
-    // Stash the service provider so the Kotlin extension function can access it
+    // Stash the service provider and the setting lookup so the Kotlin extension function can access them
     ext["codeartifactServiceProvider"] = serviceProvider
+    ext["codeartifactSettingLookup"] = settings
 
     if (!ext.has("codeartifact")) {
       logger.debug("Adding the codeartifact(url, profile|credentials, Closure) method to RepositoryHandler via extraProperties")
@@ -80,7 +83,7 @@ internal object CodeartifactRepositoryConfigurer {
           closure: Closure<*>?
         ) {
           val token = CodeArtifactAuthenticator.getToken(
-            serviceProvider.get(), logger, repoUrl, credentials, profile, DEFAULT_PROFILE
+            serviceProvider.get(), logger, settings, repoUrl, credentials, profile, DEFAULT_PROFILE
           )
           val handler = delegate as RepositoryHandler
           handler.maven { mavenRepo ->
@@ -104,7 +107,8 @@ internal object CodeartifactRepositoryConfigurer {
   private fun configRepositories(
     repositories: RepositoryHandler,
     logger: Logger,
-    serviceProvider: Provider<CodeArtifactToken>
+    serviceProvider: Provider<CodeArtifactToken>,
+    settings: SettingLookup
   ) {
     repositories.withType(MavenArtifactRepository::class.java).configureEach { artifactRepository ->
       val repoUri = artifactRepository.url
@@ -112,9 +116,10 @@ internal object CodeartifactRepositoryConfigurer {
         val token = CodeArtifactAuthenticator.getToken(
           serviceProvider.get(),
           logger,
+          settings,
           repoUri.toString(),
           profile = getProfileFromUri(repoUri),
-          fallbackProfile = getDefaultProfile()
+          fallbackProfile = getDefaultProfile(settings)
         )
         artifactRepository.credentials { creds ->
           creds.username = "aws"
@@ -125,8 +130,8 @@ internal object CodeartifactRepositoryConfigurer {
     }
   }
 
-  private fun getDefaultProfile(): String? {
-    return System.getProperty("codeartifact.profile") ?: System.getenv("CODEARTIFACT_PROFILE")
+  private fun getDefaultProfile(settings: SettingLookup): String? {
+    return settings.read("codeartifact.profile", "CODEARTIFACT_PROFILE")
   }
 
   private fun removeProfile(uri: URI): URI {

--- a/src/main/kotlin/ai/clarity/codeartifact/SettingLookup.kt
+++ b/src/main/kotlin/ai/clarity/codeartifact/SettingLookup.kt
@@ -46,9 +46,11 @@ internal fun interface SettingLookup {
      * A source that holds a value wins even when that value is blank, and a blank value resolves to `null`: a setting
      * left empty on purpose disables the ones below it rather than falling through to them.
      *
-     * Because the Gradle property now outranks the system property, a `-D` on the command line no longer overrides a
-     * plain entry in `gradle.properties` the way it overrides a `systemProp.` one. That reads as the override being
-     * ignored, so [logger] gets a warning whenever the two disagree.
+     * Because the Gradle property now outranks the sources that used to win, a `-D` on the command line or an
+     * exported environment variable no longer overrides a plain entry in `gradle.properties`. That reads as the
+     * override being ignored, so [logger] gets a warning whenever the Gradle property disagrees with the source it
+     * shadows: the system property, or — only when no system property is set, since the system property already
+     * outranked the environment before — the environment variable.
      */
     fun of(providers: ProviderFactory, logger: Logger): SettingLookup {
       val warned = ConcurrentHashMap.newKeySet<String>()
@@ -56,15 +58,21 @@ internal fun interface SettingLookup {
       return SettingLookup { property, environmentVariable ->
         val gradleProperty = providers.gradleProperty(property).orNull
         val systemProperty = providers.systemProperty(property).orNull
+        // Both resolution and the warning need the environment only when there is no system property
+        val environment = if (systemProperty == null) providers.environmentVariable(environmentVariable).orNull else null
 
-        if (gradleProperty != null && systemProperty != null && gradleProperty != systemProperty &&
-          warned.add(property)
-        ) {
-          logger.warn(shadowedSystemPropertyWarning(property))
+        val shadowingWarning = when {
+          gradleProperty == null -> null
+          systemProperty != null && systemProperty != gradleProperty -> shadowedSystemPropertyWarning(property)
+          environment != null && environment != gradleProperty ->
+            shadowedEnvironmentVariableWarning(property, environmentVariable)
+          else -> null
+        }
+        if (shadowingWarning != null && warned.add(property)) {
+          logger.warn(shadowingWarning)
         }
 
-        (gradleProperty ?: systemProperty ?: providers.environmentVariable(environmentVariable).orNull)
-          ?.takeIf { it.isNotBlank() }
+        (gradleProperty ?: systemProperty ?: environment)?.takeIf { it.isNotBlank() }
       }
     }
 
@@ -75,5 +83,13 @@ internal fun interface SettingLookup {
       "The $property Gradle property takes precedence over the $property system property, which holds a different " +
         "value and is being ignored. Override the Gradle property with -P$property, or remove it to let the system " +
         "property apply."
+
+    /**
+     * The values are deliberately left out: a shadowed `CODEARTIFACT_SECRET_ACCESS_KEY` would print the secret.
+     */
+    fun shadowedEnvironmentVariableWarning(property: String, environmentVariable: String) =
+      "The $property Gradle property takes precedence over the $environmentVariable environment variable, which " +
+        "holds a different value and is being ignored. Override the Gradle property with -P$property, or remove it " +
+        "to let the environment variable apply."
   }
 }

--- a/src/main/kotlin/ai/clarity/codeartifact/SettingLookup.kt
+++ b/src/main/kotlin/ai/clarity/codeartifact/SettingLookup.kt
@@ -1,0 +1,79 @@
+/*
+ * Copyright 2020-2026 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+
+package ai.clarity.codeartifact
+
+import org.gradle.api.logging.Logger
+import org.gradle.api.provider.ProviderFactory
+import java.util.concurrent.ConcurrentHashMap
+
+/**
+ * Reads one `codeartifact.*` setting from the sources the build may configure it in.
+ *
+ * It is an interface so that the tests can exercise every source without mutating the JVM.
+ */
+internal fun interface SettingLookup {
+
+  /**
+   * Returns the value configured as the [property] Gradle property, the [property] system property or the
+   * [environmentVariable] environment variable, or `null` when none of them holds a non-blank value.
+   */
+  fun read(property: String, environmentVariable: String): String?
+
+  companion object {
+
+    /**
+     * Reads the settings through [providers], from the closest source to the build invocation first:
+     *
+     *  1. the Gradle property, written plainly in `gradle.properties` or passed as `-P`
+     *  2. the Java system property, written as `systemProp.` in `gradle.properties` or passed as `-D`
+     *  3. the environment variable
+     *
+     * A source that holds a value wins even when that value is blank, and a blank value resolves to `null`: a setting
+     * left empty on purpose disables the ones below it rather than falling through to them.
+     *
+     * Because the Gradle property now outranks the system property, a `-D` on the command line no longer overrides a
+     * plain entry in `gradle.properties` the way it overrides a `systemProp.` one. That reads as the override being
+     * ignored, so [logger] gets a warning whenever the two disagree.
+     */
+    fun of(providers: ProviderFactory, logger: Logger): SettingLookup {
+      val warned = ConcurrentHashMap.newKeySet<String>()
+
+      return SettingLookup { property, environmentVariable ->
+        val gradleProperty = providers.gradleProperty(property).orNull
+        val systemProperty = providers.systemProperty(property).orNull
+
+        if (gradleProperty != null && systemProperty != null && gradleProperty != systemProperty &&
+          warned.add(property)
+        ) {
+          logger.warn(shadowedSystemPropertyWarning(property))
+        }
+
+        (gradleProperty ?: systemProperty ?: providers.environmentVariable(environmentVariable).orNull)
+          ?.takeIf { it.isNotBlank() }
+      }
+    }
+
+    /**
+     * The values are deliberately left out: a shadowed `codeartifact.secretAccessKey` would print the secret.
+     */
+    fun shadowedSystemPropertyWarning(property: String) =
+      "The $property Gradle property takes precedence over the $property system property, which holds a different " +
+        "value and is being ignored. Override the Gradle property with -P$property, or remove it to let the system " +
+        "property apply."
+  }
+}

--- a/src/test/kotlin/ai/clarity/codeartifact/CodeArtifactCredentialsResolverTest.kt
+++ b/src/test/kotlin/ai/clarity/codeartifact/CodeArtifactCredentialsResolverTest.kt
@@ -24,12 +24,38 @@ import org.junit.jupiter.api.Test
 
 class CodeArtifactCredentialsResolverTest {
 
-  private fun resolve(systemProperties: Map<String, String> = emptyMap(), environment: Map<String, String> = emptyMap()) =
-    CodeArtifactCredentialsResolver.resolve(systemProperties::get, environment::get)
+  private fun resolve(
+    gradleProperties: Map<String, String> = emptyMap(),
+    systemProperties: Map<String, String> = emptyMap(),
+    environment: Map<String, String> = emptyMap()
+  ) = CodeArtifactCredentialsResolver.resolve(
+    // Mirrors the precedence of SettingLookup.of: the first source that holds the setting wins, blank resolves to null
+    SettingLookup { property, environmentVariable ->
+      (gradleProperties[property] ?: systemProperties[property] ?: environment[environmentVariable])
+        ?.takeIf { it.isNotBlank() }
+    }
+  )
 
   @Test
   fun `no credentials are resolved when nothing is configured`() {
     assertThat(resolve()).isNull()
+  }
+
+  @Test
+  fun `credentials are resolved from the gradle properties`() {
+    // When
+    val credentials = resolve(
+      gradleProperties = mapOf(
+        "codeartifact.accessKeyId" to "gradle-property-key-id",
+        "codeartifact.secretAccessKey" to "gradle-property-secret",
+        "codeartifact.sessionToken" to "gradle-property-session-token"
+      )
+    )
+
+    // Then
+    assertThat(credentials).isEqualTo(
+      CodeArtifactCredentials.of("gradle-property-key-id", "gradle-property-secret", "gradle-property-session-token")
+    )
   }
 
   @Test
@@ -59,6 +85,22 @@ class CodeArtifactCredentialsResolverTest {
 
     // Then
     assertThat(credentials).isEqualTo(CodeArtifactCredentials.of("env-key-id", "env-secret", "env-session-token"))
+  }
+
+  @Test
+  fun `each gradle property takes precedence over its system property and environment variable`() {
+    // When
+    val credentials = resolve(
+      gradleProperties = mapOf("codeartifact.accessKeyId" to "gradle-property-key-id"),
+      systemProperties = mapOf("codeartifact.accessKeyId" to "sysprop-key-id"),
+      environment = mapOf(
+        "CODEARTIFACT_ACCESS_KEY_ID" to "env-key-id",
+        "CODEARTIFACT_SECRET_ACCESS_KEY" to "env-secret"
+      )
+    )
+
+    // Then
+    assertThat(credentials).isEqualTo(CodeArtifactCredentials.of("gradle-property-key-id", "env-secret"))
   }
 
   @Test
@@ -98,10 +140,18 @@ class CodeArtifactCredentialsResolverTest {
   }
 
   @Test
+  fun `blank gradle properties are ignored`() {
+    assertThat(
+      resolve(gradleProperties = mapOf("codeartifact.accessKeyId" to "  ", "codeartifact.secretAccessKey" to "  "))
+    ).isNull()
+  }
+
+  @Test
   fun `a secret access key without an access key id is rejected`() {
     assertThatThrownBy { resolve(systemProperties = mapOf("codeartifact.secretAccessKey" to "secret")) }
       .isInstanceOf(InvalidUserDataException::class.java)
-      .hasMessageContaining("codeartifact.accessKeyId")
+      .hasMessageContaining("codeartifact.accessKeyId Gradle property")
+      .hasMessageContaining("codeartifact.accessKeyId system property")
       .hasMessageContaining("CODEARTIFACT_ACCESS_KEY_ID")
   }
 
@@ -109,7 +159,8 @@ class CodeArtifactCredentialsResolverTest {
   fun `an access key id without a secret access key is rejected`() {
     assertThatThrownBy { resolve(environment = mapOf("CODEARTIFACT_ACCESS_KEY_ID" to "key-id")) }
       .isInstanceOf(InvalidUserDataException::class.java)
-      .hasMessageContaining("codeartifact.secretAccessKey")
+      .hasMessageContaining("codeartifact.secretAccessKey Gradle property")
+      .hasMessageContaining("codeartifact.secretAccessKey system property")
       .hasMessageContaining("CODEARTIFACT_SECRET_ACCESS_KEY")
   }
 }

--- a/src/test/kotlin/ai/clarity/codeartifact/CodeArtifactSettingsPluginTest.kt
+++ b/src/test/kotlin/ai/clarity/codeartifact/CodeArtifactSettingsPluginTest.kt
@@ -65,6 +65,8 @@ class CodeArtifactSettingsPluginTest {
     every { settings.pluginManagement } returns pluginManagement
     every { pluginManagement.repositories } returns pluginManagementProject.repositories
     every { settings.dependencyResolutionManagement } returns dependencyResolutionManagement
+    // A real ProviderFactory, so the plugin reads the settings the way a build does
+    every { settings.providers } returns pluginManagementProject.providers
     every { dependencyResolutionManagement.repositories } returns dependencyResolutionProject.repositories
 
     val codeArtifactUrl = "https://my-domain-111122223333.d.codeartifact.us-west-2.amazonaws.com/maven/my-repo/"
@@ -123,6 +125,8 @@ class CodeArtifactSettingsPluginTest {
     every { settings.pluginManagement } returns pluginManagement
     every { pluginManagement.repositories } returns pluginManagementProject.repositories
     every { settings.dependencyResolutionManagement } returns dependencyResolutionManagement
+    // A real ProviderFactory, so the plugin reads the settings the way a build does
+    every { settings.providers } returns pluginManagementProject.providers
     every { dependencyResolutionManagement.repositories } returns dependencyResolutionProject.repositories
 
     val codeArtifactUrl = "https://my-domain-111122223333.d.codeartifact.eu-west-1.amazonaws.com/maven/my-repo/"
@@ -174,6 +178,8 @@ class CodeArtifactSettingsPluginTest {
     every { settings.pluginManagement } returns pluginManagement
     every { pluginManagement.repositories } returns pluginManagementProject.repositories
     every { settings.dependencyResolutionManagement } returns dependencyResolutionManagement
+    // A real ProviderFactory, so the plugin reads the settings the way a build does
+    every { settings.providers } returns pluginManagementProject.providers
     every { dependencyResolutionManagement.repositories } returns dependencyResolutionProject.repositories
 
     val mavenUrl = "https://repo.maven.apache.org/maven2/"
@@ -229,6 +235,8 @@ class CodeArtifactSettingsPluginTest {
     every { settings.pluginManagement } returns pluginManagement
     every { pluginManagement.repositories } returns pluginManagementProject.repositories
     every { settings.dependencyResolutionManagement } returns dependencyResolutionManagement
+    // A real ProviderFactory, so the plugin reads the settings the way a build does
+    every { settings.providers } returns pluginManagementProject.providers
     every { dependencyResolutionManagement.repositories } returns dependencyResolutionProject.repositories
 
     // When
@@ -278,6 +286,8 @@ class CodeArtifactSettingsPluginTest {
     every { settings.pluginManagement } returns pluginManagement
     every { pluginManagement.repositories } returns pluginManagementProject.repositories
     every { settings.dependencyResolutionManagement } returns dependencyResolutionManagement
+    // A real ProviderFactory, so the plugin reads the settings the way a build does
+    every { settings.providers } returns pluginManagementProject.providers
     every { dependencyResolutionManagement.repositories } returns dependencyResolutionProject.repositories
 
     val codeArtifactUrl = "https://my-domain-111122223333.d.codeartifact.us-west-2.amazonaws.com/maven/my-repo/"
@@ -341,6 +351,8 @@ class CodeArtifactSettingsPluginTest {
     every { settings.pluginManagement } returns pluginManagement
     every { pluginManagement.repositories } returns pluginManagementProject.repositories
     every { settings.dependencyResolutionManagement } returns dependencyResolutionManagement
+    // A real ProviderFactory, so the plugin reads the settings the way a build does
+    every { settings.providers } returns pluginManagementProject.providers
     every { dependencyResolutionManagement.repositories } returns dependencyResolutionProject.repositories
 
     val codeArtifactUrl = "https://my-domain-111122223333.d.codeartifact.us-west-2.amazonaws.com/maven/my-repo/"

--- a/src/test/kotlin/ai/clarity/codeartifact/SettingLookupTest.kt
+++ b/src/test/kotlin/ai/clarity/codeartifact/SettingLookupTest.kt
@@ -1,0 +1,148 @@
+/*
+ * Copyright 2020-2026 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+
+package ai.clarity.codeartifact
+
+import io.mockk.mockk
+import io.mockk.verify
+import org.assertj.core.api.Assertions.assertThat
+import org.gradle.api.logging.Logger
+import org.gradle.testfixtures.ProjectBuilder
+import org.junit.jupiter.api.AfterEach
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.io.TempDir
+import java.io.File
+
+/**
+ * Exercises the lookup against a real [org.gradle.api.provider.ProviderFactory], so that the Gradle property and
+ * system property sources are the ones a build actually sees. The environment variable leg cannot be set from a unit
+ * test; the functional tests cover it through `GradleRunner.withEnvironment`.
+ */
+class SettingLookupTest {
+
+  private val logger = mockk<Logger>(relaxed = true)
+
+  @AfterEach
+  fun tearDown() {
+    System.clearProperty(PROFILE)
+  }
+
+  private fun lookupOf(projectDir: File, gradleProperties: String = ""): SettingLookup {
+    File(projectDir, "gradle.properties").writeText(gradleProperties)
+    val project = ProjectBuilder.builder().withProjectDir(projectDir).build()
+    return SettingLookup.of(project.providers, logger)
+  }
+
+  private fun SettingLookup.readProfile() = read(PROFILE, PROFILE_ENV)
+
+  @Test
+  fun `the gradle property takes precedence over the system property`(@TempDir projectDir: File) {
+    // Given
+    System.setProperty(PROFILE, "from-system-property")
+    val lookup = lookupOf(projectDir, "$PROFILE=from-gradle-property")
+
+    // When / Then
+    assertThat(lookup.readProfile()).isEqualTo("from-gradle-property")
+  }
+
+  @Test
+  fun `the system property is used when there is no gradle property`(@TempDir projectDir: File) {
+    // Given
+    System.setProperty(PROFILE, "from-system-property")
+    val lookup = lookupOf(projectDir)
+
+    // When / Then
+    assertThat(lookup.readProfile()).isEqualTo("from-system-property")
+  }
+
+  @Test
+  fun `the environment variable is used when neither property is set`(@TempDir projectDir: File) {
+    // Given: PATH is the one environment variable a unit test can count on being set
+    val lookup = lookupOf(projectDir)
+
+    // When / Then
+    assertThat(lookup.read(PROFILE, "PATH")).isEqualTo(System.getenv("PATH"))
+  }
+
+  @Test
+  fun `nothing is resolved when no source is set`(@TempDir projectDir: File) {
+    assertThat(lookupOf(projectDir).read(PROFILE, "CODEARTIFACT_ABSENT_ENVIRONMENT_VARIABLE")).isNull()
+  }
+
+  @Test
+  fun `a blank gradle property resolves to null instead of falling through`(@TempDir projectDir: File) {
+    // Given: a setting emptied on purpose disables the sources below it
+    System.setProperty(PROFILE, "from-system-property")
+    val lookup = lookupOf(projectDir, "$PROFILE=")
+
+    // When / Then
+    assertThat(lookup.readProfile()).isNull()
+  }
+
+  @Test
+  fun `a gradle property shadowing a different system property warns once`(@TempDir projectDir: File) {
+    // Given
+    System.setProperty(PROFILE, "ci")
+    val lookup = lookupOf(projectDir, "$PROFILE=dev")
+
+    // When: the configurer reads the same setting once per repository
+    lookup.readProfile()
+    lookup.readProfile()
+
+    // Then
+    verify(exactly = 1) { logger.warn(SettingLookup.shadowedSystemPropertyWarning(PROFILE)) }
+  }
+
+  @Test
+  fun `no warning when the gradle property and the system property agree`(@TempDir projectDir: File) {
+    // Given
+    System.setProperty(PROFILE, "dev")
+    val lookup = lookupOf(projectDir, "$PROFILE=dev")
+
+    // When
+    lookup.readProfile()
+
+    // Then
+    verify(exactly = 0) { logger.warn(SettingLookup.shadowedSystemPropertyWarning(PROFILE)) }
+  }
+
+  @Test
+  fun `no warning when only the gradle property is set`(@TempDir projectDir: File) {
+    // Given
+    val lookup = lookupOf(projectDir, "$PROFILE=dev")
+
+    // When
+    lookup.readProfile()
+
+    // Then
+    verify(exactly = 0) { logger.warn(SettingLookup.shadowedSystemPropertyWarning(PROFILE)) }
+  }
+
+  @Test
+  fun `the warning never names the value, so a shadowed secret cannot leak`() {
+    assertThat(SettingLookup.shadowedSystemPropertyWarning("codeartifact.secretAccessKey")).isEqualTo(
+      "The codeartifact.secretAccessKey Gradle property takes precedence over the codeartifact.secretAccessKey " +
+        "system property, which holds a different value and is being ignored. Override the Gradle property with " +
+        "-Pcodeartifact.secretAccessKey, or remove it to let the system property apply."
+    )
+  }
+
+  private companion object {
+    const val PROFILE = "codeartifact.profile"
+    const val PROFILE_ENV = "CODEARTIFACT_PROFILE"
+  }
+}

--- a/src/test/kotlin/ai/clarity/codeartifact/SettingLookupTest.kt
+++ b/src/test/kotlin/ai/clarity/codeartifact/SettingLookupTest.kt
@@ -126,10 +126,54 @@ class SettingLookupTest {
     val lookup = lookupOf(projectDir, "$PROFILE=dev")
 
     // When
-    lookup.readProfile()
+    lookup.read(PROFILE, ABSENT_ENV)
 
     // Then
     verify(exactly = 0) { logger.warn(SettingLookup.shadowedSystemPropertyWarning(PROFILE)) }
+    verify(exactly = 0) { logger.warn(SettingLookup.shadowedEnvironmentVariableWarning(PROFILE, ABSENT_ENV)) }
+  }
+
+  @Test
+  fun `a gradle property shadowing a different environment variable warns once`(@TempDir projectDir: File) {
+    // Given: PATH stands in for CODEARTIFACT_PROFILE, being the one environment variable a unit test can count on
+    val lookup = lookupOf(projectDir, "$PROFILE=dev")
+
+    // When: the configurer reads the same setting once per repository
+    lookup.read(PROFILE, "PATH")
+    lookup.read(PROFILE, "PATH")
+
+    // Then: the gradle property wins, and the shadowed environment variable is warned about once
+    assertThat(lookup.read(PROFILE, "PATH")).isEqualTo("dev")
+    verify(exactly = 1) { logger.warn(SettingLookup.shadowedEnvironmentVariableWarning(PROFILE, "PATH")) }
+  }
+
+  @Test
+  fun `only the system property warning is logged when both lower sources are shadowed`(@TempDir projectDir: File) {
+    // Given: the system property outranked the environment variable before this plugin read Gradle properties,
+    // so it is the only override that actually stopped working
+    System.setProperty(PROFILE, "ci")
+    val lookup = lookupOf(projectDir, "$PROFILE=dev")
+
+    // When
+    lookup.read(PROFILE, "PATH")
+
+    // Then
+    verify(exactly = 1) { logger.warn(SettingLookup.shadowedSystemPropertyWarning(PROFILE)) }
+    verify(exactly = 0) { logger.warn(SettingLookup.shadowedEnvironmentVariableWarning(PROFILE, "PATH")) }
+  }
+
+  @Test
+  fun `no environment variable warning when the system property agrees with the gradle property`(@TempDir projectDir: File) {
+    // Given: the environment variable differs, but it was already shadowed by the system property before
+    System.setProperty(PROFILE, "dev")
+    val lookup = lookupOf(projectDir, "$PROFILE=dev")
+
+    // When
+    lookup.read(PROFILE, "PATH")
+
+    // Then
+    verify(exactly = 0) { logger.warn(SettingLookup.shadowedSystemPropertyWarning(PROFILE)) }
+    verify(exactly = 0) { logger.warn(SettingLookup.shadowedEnvironmentVariableWarning(PROFILE, "PATH")) }
   }
 
   @Test
@@ -141,8 +185,20 @@ class SettingLookupTest {
     )
   }
 
+  @Test
+  fun `the environment variable warning never names the value either`() {
+    assertThat(
+      SettingLookup.shadowedEnvironmentVariableWarning("codeartifact.secretAccessKey", "CODEARTIFACT_SECRET_ACCESS_KEY")
+    ).isEqualTo(
+      "The codeartifact.secretAccessKey Gradle property takes precedence over the CODEARTIFACT_SECRET_ACCESS_KEY " +
+        "environment variable, which holds a different value and is being ignored. Override the Gradle property " +
+        "with -Pcodeartifact.secretAccessKey, or remove it to let the environment variable apply."
+    )
+  }
+
   private companion object {
     const val PROFILE = "codeartifact.profile"
     const val PROFILE_ENV = "CODEARTIFACT_PROFILE"
+    const val ABSENT_ENV = "CODEARTIFACT_ABSENT_ENVIRONMENT_VARIABLE"
   }
 }


### PR DESCRIPTION
Reads every `codeartifact.*` setting through `ProviderFactory` so the plain `gradle.properties` form and `-P` work, alongside the `systemProp.` / `-D` and `CODEARTIFACT_*` forms that already did. Existing builds are unaffected: the precedence list only grows a step at the top.

Closes #816.

## Resolution order

Each setting is now looked up in three places, first one that *holds* it wins:

| # | Source | Written as |
|---|---|---|
| 1 | Gradle property | plain `codeartifact.profile=dev`, or `-Pcodeartifact.profile=dev` |
| 2 | Java system property | `systemProp.codeartifact.profile=dev`, or `-Dcodeartifact.profile=dev` |
| 3 | environment variable | `CODEARTIFACT_PROFILE` |

A blank value counts as "held" and resolves to *not configured*, so a setting emptied on purpose disables the sources below it rather than falling through — that preserves the existing `blank values are ignored` behaviour.

## The one behaviour worth reviewing

Putting the Gradle property on top means the two sources that used to win no longer override a committed **plain** entry: `-D` loses to it, and so does an exported `CODEARTIFACT_*` variable. The README's recommended CI pattern (commit the default, override in CI) is exactly where that bites: a team migrating the committed entry to the plain form while CI still passes `-D` — or a build carrying a stale plain entry while authenticating through `CODEARTIFACT_*` exports — would get a silently ignored override, the same failure class this issue is about. The stale-entry case can be nastier still: a plain `codeartifact.accessKeyId` left behind pairs with the `CODEARTIFACT_SECRET_ACCESS_KEY` from the environment into a mismatched credential pair and a confusing 403.

So whenever the Gradle property disagrees with the source it shadows — the system property, or, when no system property is set, the environment variable — the build warns once per setting:

```
The codeartifact.profile Gradle property takes precedence over the codeartifact.profile
system property, which holds a different value and is being ignored. Override the Gradle
property with -Pcodeartifact.profile, or remove it to let the system property apply.
```

(the environment-variable variant names `CODEARTIFACT_PROFILE` instead). A system property shadowing the environment variable is deliberately *not* warned about: that precedence predates this change, so nothing stopped working there.

The message names the setting but never the values, so a shadowed `codeartifact.secretAccessKey` cannot leak into the log. There is a test asserting exactly that, for each variant.

## Structure

The lookup lives in the new `SettingLookup`, built from `project.providers` / `settings.providers` and threaded through `CodeartifactRepositoryConfigurer` to both entry points, the Groovy closure, and — via `extraProperties` next to the token `BuildService` — the `RepositoryHandler.codeartifact()` Kotlin extension. That plumbing is the bulk of the diff, as the issue predicted.

`CodeArtifactCredentialsResolver.resolve()` loses its two lookup lambdas in favour of a single `SettingLookup`, and its `Incomplete CodeArtifact service credentials` message now names all three sources.

## Testing

`./gradlew build` green: **102 unit tests** (was 86) and **106 functional tests** (was 85), plus `validatePlugins`.

<details>
<summary>Evidence, 2026-09-01</summary>

**`providers` in a Settings script, measured on Gradle 8.4** — the oldest version in the compat matrix, and the leg most at risk since `Settings.getProviders()` is the newer API:

| lookup | `codeartifact.profile=x` | `systemProp.codeartifact.profile=x` | `-Px=…` | `-Dx=…` |
|---|---|---|---|---|
| `providers.gradleProperty` | yes | — | yes | — |
| `providers.systemProperty` | — | yes | — | yes |

The second row is the no-regression check: swapping `System.getProperty` for `providers.systemProperty` keeps seeing everything it saw before. A blank gradle property comes back present-with-`""`, which is what preserves the blank semantics.

**The new tests fail without the fix.** Temporarily forcing the `gradleProperty` leg to `null` and re-running fails exactly 16 tests — the 3 new parameterized ones across 5 Gradle versions plus the 1 new plain test — and no pre-existing test. That is the backward-compatibility evidence as much as the regression-guard evidence.

**The environment-variable warning is guarded the same way.** Disabling just that leg of the warning fails exactly the 6 tests that assert it fires — 1 unit test plus the parameterized functional one across 5 Gradle versions — and nothing else.

**Unit-test harness change.** `CodeArtifactSettingsPluginTest` mocks `Settings` wholesale, so `settings.providers` came back as a relaxed mock whose `orNull` returns a bare `Object` — a `ClassCastException` in the test only, never in a real build. Those six tests now get a real `ProviderFactory` from their `ProjectBuilder` project, which also makes them exercise the real lookup.

</details>
