### PR TITLE
chore: prepare 0.2.1

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ In your `build.gradle.kts` file:
 
 ```kotlin
 plugins {
-  id("ai.clarity.codeartifact") version "0.2.0"
+  id("ai.clarity.codeartifact") version "0.2.1"
 }
 
 repositories {
@@ -40,7 +40,7 @@ In your `build.gradle.kts` file:
 
 ```kotlin
 plugins {
-  id("ai.clarity.codeartifact") version "0.2.0"
+  id("ai.clarity.codeartifact") version "0.2.1"
 }
 
 publishing {
@@ -60,7 +60,7 @@ In your `build.gradle` file:
 
 ```groovy
 plugins {
-    id 'ai.clarity.codeartifact' version '0.2.0'
+    id 'ai.clarity.codeartifact' version '0.2.1'
 }
 
 repositories {
@@ -76,7 +76,7 @@ In your `build.gradle` file:
 
 ```groovy
 plugins {
-    id 'ai.clarity.codeartifact' version '0.2.0'
+    id 'ai.clarity.codeartifact' version '0.2.1'
 }
 
 publishing {
@@ -165,7 +165,7 @@ In your `settings.gradle.kts` file:
 
 ```kotlin
 plugins {
-  id("ai.clarity.codeartifact") version "0.2.0"
+  id("ai.clarity.codeartifact") version "0.2.1"
 }
 
 dependencyResolutionManagement {
@@ -183,7 +183,7 @@ In your `settings.gradle.kts` file:
 
 ```kotlin
 plugins {
-  id("ai.clarity.codeartifact") version "0.2.0"
+  id("ai.clarity.codeartifact") version "0.2.1"
 }
 
 pluginManagement {
@@ -203,7 +203,7 @@ In your `settings.gradle` file:
 
 ```groovy
 plugins {
-    id 'ai.clarity.codeartifact' version '0.2.0'
+    id 'ai.clarity.codeartifact' version '0.2.1'
 }
 
 dependencyResolutionManagement {
@@ -221,7 +221,7 @@ In your `settings.gradle` file:
 
 ```groovy
 plugins {
-    id 'ai.clarity.codeartifact' version '0.2.0'
+    id 'ai.clarity.codeartifact' version '0.2.1'
 }
 
 pluginManagement {

--- a/docs/ONBOARDING.md
+++ b/docs/ONBOARDING.md
@@ -111,7 +111,7 @@ Gradle cannot run inside the Claude Code sandbox — disable it for every `./gra
 
 ```kotlin
 // build.gradle.kts
-plugins { id("ai.clarity.codeartifact") version "0.2.0" }
+plugins { id("ai.clarity.codeartifact") version "0.2.1" }
 repositories {
   maven { url = uri("https://my-domain-111122223333.d.codeartifact.us-west-2.amazonaws.com/maven/my-repo/") }
 }
@@ -295,8 +295,10 @@ profile, since `ProfileCredentialsProvider` bypasses `AWS_ACCESS_KEY_ID`.
 
 Version lives in `gradle.properties` (a `-SNAPSHOT` between releases). `net.researchgate.release`
 drives the flow: `./gradlew release` un-snapshots, commits, tags, bumps to the next snapshot, and
-requires `main`. Pushing the resulting tag is what publishes to the portal. Latest published
-version: **0.2.0**. Dependabot bumps Gradle deps and Actions daily.
+requires `main`. Pushing the resulting tag is what publishes to the portal; the latest published
+version is the one shown on the
+[Gradle Plugin Portal](https://plugins.gradle.org/plugin/ai.clarity.codeartifact).
+Dependabot bumps Gradle deps and Actions daily.
 
 Never run `release` or `publishPlugins` from an agent session — both are outward-facing.
 


### PR DESCRIPTION
Release preparation for **0.2.1**. Docs only — no source change.

Bumps the nine `version "0.2.0"` pins in the README and `docs/ONBOARDING.md` to `0.2.1`, so anyone copy-pasting an example after the release gets the version that is actually out. Same step the 0.2.0 preparation did in #817.

Also drops the hardcoded `Latest published version: **0.2.0**` from the release section in favour of a link to the [Gradle Plugin Portal](https://plugins.gradle.org/plugin/ai.clarity.codeartifact). The 0.2.0 pass set out to replace references that go stale on every release and missed this one; the link cannot go stale.

Merge this before running `./gradlew release`, so the tag carries the right pins.

## What 0.2.1 contains

One user-facing change, #816 (PR #819): the `codeartifact.*` settings are now accepted as plain Gradle properties and `-P`, not only as `systemProp.` / `-D` / `CODEARTIFACT_*`. Purely additive for the existing forms, with a warning when a plain `gradle.properties` entry shadows a differently-valued system property or environment variable.
