### PR TITLE
fix: detect and parse the real dualstack CodeArtifact endpoint

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -103,6 +103,10 @@ experiments):
 1. Non-CodeArtifact repositories are left completely untouched (credentials stay `null`).
 2. A CodeArtifact repository that **already has credentials** is skipped.
 3. `?profile=<name>` is read from the URL and then **stripped** from the final repository URL.
+   Both public host shapes are detected and parsed: the ipv4 one
+   (`{domain}-{owner}.d.codeartifact.{region}.amazonaws.com`) and the dualstack one
+   (`{domain}-{owner}.codeartifact.{region}.on.aws`, which has **no** `.d.` segment). A host that
+   mixes the two is rejected.
 4. Credentials precedence, closest-to-the-repository first: credentials passed to
    `codeartifact()` → `?profile=` or a profile passed to `codeartifact()` →
    `codeartifact.accessKeyId`/`secretAccessKey` → `codeartifact.profile` → *null* (AWS default
@@ -128,10 +132,6 @@ experiments):
 
 ## Known gaps — do not document these as working
 
-- **Dualstack `.on.aws` endpoints are not auto-detected.** `CodeArtifactUrl` accepts them, but
-  `CodeartifactRepositoryConfigurer.isCodeArtifactUri` requires `.amazonaws.`, so a
-  `maven { url = ".../codeartifact.<region>.on.aws/..." }` silently gets no credentials. The
-  explicit `codeartifact(...)` helper *does* work with dualstack URLs.
 - **VPC endpoints are unsupported by design** (domain/owner live in the path, not the host).
 - **`codeartifact(url)` with no profile falls back to the `default` profile** — it honours the
   build-wide service credentials, but still ignores `codeartifact.profile`,

--- a/README.md
+++ b/README.md
@@ -8,6 +8,16 @@ the token.
 The plugin automatically detects any Maven repository whose URL matches a CodeArtifact endpoint and injects the
 appropriate credentials — no extra configuration needed.
 
+Both public endpoint shapes that `aws codeartifact get-repository-endpoint` returns are recognised:
+
+| Endpoint type | Repository URL |
+|---|---|
+| `ipv4` | `https://{domain}-{owner}.d.codeartifact.{region}.amazonaws.com/{format}/{repository}/` |
+| `dualstack` | `https://{domain}-{owner}.codeartifact.{region}.on.aws/{format}/{repository}/` |
+
+Note the dualstack host has no `.d.` segment. VPC endpoints are not supported: they carry the domain and owner in the
+path rather than the host.
+
 ## Usage
 
 The plugin can be applied to either your project's `build.gradle(.kts)` file or to your `settings.gradle(.kts)` file.

--- a/docs/ONBOARDING.md
+++ b/docs/ONBOARDING.md
@@ -306,7 +306,7 @@ Never run `release` or `publishPlugins` from an agent session — both are outwa
 
 | Symptom | Cause |
 |---|---|
-| Repository silently unauthenticated, URL ends in `.on.aws` | `isCodeArtifactUri` requires `.amazonaws.`; dualstack endpoints are not auto-detected. Use the explicit `codeartifact(url)` helper, which accepts them. |
+| `Not a valid CodeArtifact repository URL` on an `.on.aws` host | The dualstack host has no `.d.` segment: `{domain}-{owner}.codeartifact.{region}.on.aws`. Copy it from `aws codeartifact get-repository-endpoint --endpoint-type dualstack` rather than editing the ipv4 one by hand. |
 | `Not a valid CodeArtifact repository URL: …` | Host does not match `{domain}-{owner}.d.codeartifact.{region}.…` — e.g. a missing `-{owner}`, or a VPC endpoint. Fails the build by design. |
 | `Unresolved reference 'codeartifact'` | Missing `import ai.clarity.codeartifact.codeartifact` in a `.kts` file (`CodeArtifactCredentials` needs its own import). |
 | `Could not find method codeartifact()` inside `pluginManagement` | The block runs before the plugin is applied. Use `maven { url = … }` there. |
@@ -320,7 +320,7 @@ Never run `release` or `publishPlugins` from an agent session — both are outwa
 
 ## 10. README discrepancies (as of 2026-09-01)
 
-One left: dualstack `.on.aws` endpoints are undocumented and not auto-detected (see §9).
+None left. Dualstack `.on.aws` endpoints are auto-detected since 0.2.2.
 
 Four earlier defects are fixed: the stale version pins in the examples, the false "the helper is
 not available in `settings.gradle(.kts)`" note, the missing Kotlin imports in the

--- a/src/main/java/ai/clarity/codeartifact/CodeArtifactUrl.java
+++ b/src/main/java/ai/clarity/codeartifact/CodeArtifactUrl.java
@@ -24,16 +24,24 @@ import java.util.regex.Pattern;
 
 class CodeArtifactUrl {
 
-  // Accepts the public CodeArtifact repository hosts, both the standard endpoint
-  // ({domain}-{owner}.d.codeartifact.{region}.amazonaws.com) and the dualstack one
-  // ({domain}-{owner}.d.codeartifact.{region}.on.aws). VPC endpoints
-  // (vpce-*.d.codeartifact.{region}.vpce.amazonaws.com) carry the domain and owner in
-  // the path instead of the host and are not supported.
+  // Accepts the two public CodeArtifact repository hosts that GetRepositoryEndpoint returns:
+  //
+  //   ipv4       {domain}-{owner}.d.codeartifact.{region}.amazonaws.com
+  //   dualstack  {domain}-{owner}.codeartifact.{region}.on.aws
+  //
+  // The dualstack host has no ".d." segment — verified against a live domain with
+  // `aws codeartifact get-repository-endpoint --endpoint-type dualstack`. The two shapes are
+  // paired with their own suffix rather than folded together, so a host that mixes them is
+  // reported as invalid instead of being sent to a name that never resolves.
+  //
+  // VPC endpoints (vpce-*.d.codeartifact.{region}.vpce.amazonaws.com) carry the domain and owner
+  // in the path instead of the host and are not supported.
   private static final Pattern HOST_PATTERN = Pattern.compile(
-    "(?i)^([^.]+)-([^-.]+)\\.d\\.codeartifact\\.([^.]+)\\.(?:amazonaws\\..+|on\\.aws)$");
+    "(?i)^([^.]+)-([^-.]+)\\.(?:d\\.codeartifact\\.([^.]+)\\.amazonaws\\..+|codeartifact\\.([^.]+)\\.on\\.aws)$");
 
   private static final String EXPECTED_FORMAT =
-    "https://{domain}-{owner}.d.codeartifact.{region}.amazonaws.com/{format}/{repository}/";
+    "https://{domain}-{owner}.d.codeartifact.{region}.amazonaws.com/{format}/{repository}/ "
+      + "or https://{domain}-{owner}.codeartifact.{region}.on.aws/{format}/{repository}/";
 
   private final URL url;
   private final String artifactDomain;
@@ -51,7 +59,8 @@ class CodeArtifactUrl {
     path = url.getPath();
     artifactDomain = host.group(1);
     artifactOwner = host.group(2);
-    region = host.group(3);
+    // Only one of the two alternatives matches, so exactly one region group is set
+    region = host.group(3) != null ? host.group(3) : host.group(4);
   }
 
   public CodeArtifactUrl(String artifactDomain, String artifactOwner, String region, String path) throws MalformedURLException {

--- a/src/main/kotlin/ai/clarity/codeartifact/CodeartifactRepositoryConfigurer.kt
+++ b/src/main/kotlin/ai/clarity/codeartifact/CodeartifactRepositoryConfigurer.kt
@@ -142,8 +142,13 @@ internal object CodeartifactRepositoryConfigurer {
     return mavenRepo.credentials.password == null && mavenRepo.credentials.username == null
   }
 
+  // Matched against the host alone, so that a CodeArtifact-looking path cannot pass for an
+  // endpoint. Covers the ipv4 host ({domain}-{owner}.d.codeartifact.{region}.amazonaws.com) and the
+  // dualstack one ({domain}-{owner}.codeartifact.{region}.on.aws), which has no ".d." segment.
+  private val CODEARTIFACT_HOST = "(?i).+\\.codeartifact\\..+\\.(?:amazonaws\\..+|on\\.aws)".toRegex()
+
   private fun isCodeArtifactUri(uri: URI): Boolean {
-    return uri.toString().matches("(?i).+\\.codeartifact\\..+\\.amazonaws\\..+".toRegex())
+    return uri.host?.matches(CODEARTIFACT_HOST) == true
   }
 
   private fun getProfileFromUri(uri: URI): String? {

--- a/src/test/java/ai/clarity/codeartifact/CodeArtifactUrlTest.java
+++ b/src/test/java/ai/clarity/codeartifact/CodeArtifactUrlTest.java
@@ -55,14 +55,34 @@ class CodeArtifactUrlTest {
 
   @Test
   void testOfWithDualstackUrl() throws MalformedURLException {
+    // given: the shape GetRepositoryEndpoint returns for --endpoint-type dualstack, which unlike the
+    // ipv4 one has no ".d." segment
     // when
-    CodeArtifactUrl url = CodeArtifactUrl.of("https://my-domain-111122223333.d.codeartifact.us-west-2.on.aws/maven/my-repo/");
+    CodeArtifactUrl url = CodeArtifactUrl.of("https://my-domain-111122223333.codeartifact.us-west-2.on.aws/maven/my-repo/");
 
     // then
     assertThat(url.getRegion()).isEqualTo("us-west-2");
     assertThat(url.getArtifactDomain()).isEqualTo("my-domain");
     assertThat(url.getArtifactOwner()).isEqualTo("111122223333");
     assertThat(url.getPath()).isEqualTo("/maven/my-repo/");
+  }
+
+  @Test
+  void testOfWithDualstackHostCarryingTheIpv4DotDSegment() {
+    // given: a host mixing the two shapes, which CodeArtifact never returns
+    assertThatThrownBy(
+      () -> CodeArtifactUrl.of("https://my-domain-111122223333.d.codeartifact.us-west-2.on.aws/maven/my-repo/"))
+      .isInstanceOf(MalformedURLException.class)
+      .hasMessageContaining("Not a valid CodeArtifact repository URL");
+  }
+
+  @Test
+  void testOfWithIpv4HostMissingTheDotDSegment() {
+    // given: the mirror image — the amazonaws.com suffix always carries ".d."
+    assertThatThrownBy(
+      () -> CodeArtifactUrl.of("https://my-domain-111122223333.codeartifact.us-west-2.amazonaws.com/maven/my-repo/"))
+      .isInstanceOf(MalformedURLException.class)
+      .hasMessageContaining("Not a valid CodeArtifact repository URL");
   }
 
   @Test

--- a/src/test/kotlin/ai/clarity/codeartifact/CodeArtifactProjectPluginTest.kt
+++ b/src/test/kotlin/ai/clarity/codeartifact/CodeArtifactProjectPluginTest.kt
@@ -56,6 +56,35 @@ class CodeArtifactProjectPluginTest {
   }
 
   @Test
+  fun `plugin configures credentials for dualstack codeartifact repository URLs`() {
+    // Given: the host GetRepositoryEndpoint returns for --endpoint-type dualstack, which has no
+    // ".d." segment and ends in .on.aws rather than .amazonaws.com
+    val mockResponse = GetAuthorizationTokenResponse.builder()
+      .authorizationToken("mock-token")
+      .build()
+
+    mockkStatic(TokenFactory::class)
+    every { TokenFactory.getAuthorizationToken(any<CodeArtifactUrl>(), any<String>()) } returns mockResponse
+
+    val project = ProjectBuilder.builder().build()
+    project.plugins.apply("ai.clarity.codeartifact")
+
+    val dualstackUrl = "https://my-domain-111122223333.codeartifact.us-west-2.on.aws/maven/my-repo/"
+
+    // When
+    project.repositories.maven { repo ->
+      repo.url = URI(dualstackUrl)
+    }
+    val repository = project.repositories.first() as MavenArtifactRepository
+
+    // Then: the repository is detected and authenticated, not silently left alone
+    assertThat(repository.credentials.username).isEqualTo("aws")
+    assertThat(repository.credentials.password).isEqualTo("mock-token")
+
+    verify(exactly = 1) { TokenFactory.getAuthorizationToken(any<CodeArtifactUrl>(), any<String>()) }
+  }
+
+  @Test
   fun `plugin ignores non-codeartifact repositories`() {
     // Given
     val project = ProjectBuilder.builder().build()


### PR DESCRIPTION
Dualstack CodeArtifact endpoints could not be used by either code path. The host shape the plugin expected was assumed rather than checked, and the test covering it asserted the assumption, so the suite stayed green through the defect.

## What CodeArtifact actually returns

Verified against a live domain with `aws codeartifact get-repository-endpoint`:

```
ipv4       https://<domain>-<owner>.d.codeartifact.eu-central-1.amazonaws.com/maven/<repo>/
dualstack  https://<domain>-<owner>.codeartifact.eu-central-1.on.aws/maven/<repo>/
```

**The dualstack host has no `.d.` segment.** That is the part the original change guessed wrong — it got the `.on.aws` suffix right and kept `.d.` from the ipv4 shape.

## The two failures

`HOST_PATTERN` hardcoded `\.d\.` before `codeartifact` for both suffixes:

- **`CodeArtifactUrl` rejected every real dualstack URL** — `Not a valid CodeArtifact repository URL`. Passing one to `codeartifact()` failed the build outright, despite `AGENTS.md` and the 0.2.0/0.2.1 release notes stating the helper handled dualstack.
- **`isCodeArtifactUri` required `.amazonaws.`**, so automatic detection skipped the same URL silently and left the repository unauthenticated.

Probing the pre-fix code with the real endpoint:

| URL | `CodeArtifactUrl` | auto-detect |
|---|---|---|
| real ipv4 | accept | yes |
| **real dualstack** | **reject** | **no** |
| invented `…d.codeartifact.<region>.on.aws` | accept | no |

That last row is what `testOfWithDualstackUrl` asserted: our own regex fed a host AWS never emits.

## The fix

`HOST_PATTERN` now pairs each host shape with its own suffix rather than folding them together, so a host that mixes the two is reported as invalid instead of being sent to a name that never resolves. `isCodeArtifactUri` matches on `uri.host` instead of the whole URI string — that covers both suffixes and, incidentally, stops a CodeArtifact-looking *path* from passing for an endpoint.

## Testing

`./gradlew build` green: 105 unit (was 102) and 106 functional.

`testOfWithDualstackUrl` now uses the real endpoint shape, and two new tests pin the rejection of each mixed host. `CodeArtifactProjectPluginTest` gains a dualstack auto-detection test — the path that was failing silently, and the one no test covered at all.

<details>
<summary>Evidence, 2026-09-01</summary>

Reverting just the two regexes fails exactly three tests — the two changed and the new detection one — and no pre-existing test:

```
- CodeArtifactProjectPluginTest::plugin configures credentials for dualstack codeartifact repository URLs()
- CodeArtifactUrlTest::testOfWithDualstackHostCarryingTheIpv4DotDSegment()
- CodeArtifactUrlTest::testOfWithDualstackUrl()
```

`testOfWithIpv4HostMissingTheDotDSegment` passes against both the old and the new pattern, which is correct — the old one already rejected it.

The AWS docs are no help here and were the reason this went unnoticed: the [endpoints and quotas page](https://docs.aws.amazon.com/general/latest/gr/codeartifact.html) lists only `codeartifact.{region}.amazonaws.com`, and neither the [API reference](https://docs.aws.amazon.com/codeartifact/latest/APIReference/API_GetRepositoryEndpoint.html) nor the CLI reference gives a dualstack example, though both document `endpointType: dualstack | ipv4`. CodeArtifact's dualstack support itself is confirmed on the [AWS services that support IPv6](https://docs.aws.amazon.com/vpc/latest/userguide/aws-ipv6-support.html) page. The only way to learn the host is to ask the service.

</details>

## Docs

Removes the "dualstack is not auto-detected" known gap from `AGENTS.md` and `docs/ONBOARDING.md`, replaces the ONBOARDING gotcha row with the `.d.`-segment explanation, and adds a short table of the two supported endpoint shapes to the README, which never stated them.
