### PR TITLE
fix: document the Java public surface and fail the build on new gaps

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -26,7 +26,7 @@ Use the AWS documentation placeholders (`my-domain-111122223333`, `us-west-2`) a
 | AWS | `software.amazon.awssdk` BOM — `codeartifact`, `sts`, `sso`, `ssooidc` |
 | Tests | JUnit 5 + AssertJ + MockK; Gradle TestKit for `functionalTest` |
 | Release | `net.researchgate.release` + `com.gradle.plugin-publish`, GitHub Actions |
-| Lint/format | **none configured** — match surrounding style by hand |
+| Lint/format | no linter or formatter; `javadoc -Werror` is the only automated gate — match surrounding style by hand |
 
 ## Commands
 
@@ -142,7 +142,10 @@ experiments):
 - **The `codeartifact()` helper does not work inside `pluginManagement`** (that block runs
   before `plugins { }` applies the plugin). It does work inside
   `dependencyResolutionManagement`, in both DSLs.
-- **No linter or formatter** is wired into the build; `./gradlew check` will not catch style.
+- **No linter or formatter** is wired into the build; `./gradlew check` will not catch style. The one
+  automated gate is `javadoc -Werror`: every public member of the four Java classes is documented, and
+  `javadoc` runs as part of `build`, so an undocumented one fails the build. Kotlin is not covered — there
+  is no Dokka.
 
 ## README caveats
 

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -90,6 +90,12 @@ tasks.named<Test>("test") {
   useJUnitPlatform()
 }
 
+tasks.javadoc {
+  // The javadoc jar is part of the publication, so a missing comment ships to consumers' IDEs. The whole surface is
+  // documented; -Werror is what stops it regrowing, and `javadoc` already runs as part of `build`.
+  (options as StandardJavadocDocletOptions).addBooleanOption("Werror", true)
+}
+
 
 release {
   git {

--- a/src/main/java/ai/clarity/codeartifact/CodeArtifactCredentials.java
+++ b/src/main/java/ai/clarity/codeartifact/CodeArtifactCredentials.java
@@ -56,10 +56,27 @@ public final class CodeArtifactCredentials {
     this.sessionToken = emptyToNull(sessionToken);
   }
 
+  /**
+   * Builds the long-lived credentials of an IAM user.
+   *
+   * @param accessKeyId     the access key id, required
+   * @param secretAccessKey the secret access key, required
+   * @return the credentials
+   * @throws IllegalArgumentException when either value is missing or blank
+   */
   public static CodeArtifactCredentials of(String accessKeyId, String secretAccessKey) {
     return new CodeArtifactCredentials(accessKeyId, secretAccessKey, null);
   }
 
+  /**
+   * Builds the credentials of an IAM user, or the temporary ones of an assumed role when a session token is given.
+   *
+   * @param accessKeyId     the access key id, required
+   * @param secretAccessKey the secret access key, required
+   * @param sessionToken    the session token of temporary credentials, or {@code null} for long-lived ones
+   * @return the credentials
+   * @throws IllegalArgumentException when the access key id or the secret access key is missing or blank
+   */
   public static CodeArtifactCredentials of(String accessKeyId, String secretAccessKey, String sessionToken) {
     return new CodeArtifactCredentials(accessKeyId, secretAccessKey, sessionToken);
   }
@@ -67,6 +84,12 @@ public final class CodeArtifactCredentials {
   /**
    * Builds the credentials from a map, which is the shape the Groovy DSL passes them in, as in
    * {@code codeartifact(url, [accessKeyId: '...', secretAccessKey: '...'])}.
+   *
+   * @param values the credentials keyed by {@code accessKeyId}, {@code secretAccessKey} and, optionally,
+   *               {@code sessionToken}
+   * @return the credentials
+   * @throws IllegalArgumentException when the map carries an unsupported key, or the access key id or the secret
+   *                                  access key is missing or blank
    */
   public static CodeArtifactCredentials of(Map<?, ?> values) {
     Set<String> unsupported = new LinkedHashSet<>();
@@ -87,12 +110,20 @@ public final class CodeArtifactCredentials {
       asString(values.get(SESSION_TOKEN), SESSION_TOKEN));
   }
 
+  /**
+   * Returns the access key id in clear. Use {@link #getMaskedAccessKeyId()} for anything that reaches a log.
+   *
+   * @return the access key id
+   */
   public String getAccessKeyId() {
     return accessKeyId;
   }
 
   /**
    * The access key id with its middle section hidden, safe to write to the build log.
+   *
+   * @return the access key id with all but its first and last four characters replaced by asterisks, or fully masked
+   *         when it is eight characters or shorter
    */
   public String getMaskedAccessKeyId() {
     if (accessKeyId.length() <= 8) {

--- a/src/main/java/ai/clarity/codeartifact/CodeArtifactToken.java
+++ b/src/main/java/ai/clarity/codeartifact/CodeArtifactToken.java
@@ -23,14 +23,46 @@ import org.gradle.api.services.BuildService;
 import org.gradle.api.services.BuildServiceParameters;
 import org.gradle.api.services.BuildServiceParameters.None;
 
+/**
+ * Build service that fetches CodeArtifact authorization tokens and shares them across the whole build.
+ *
+ * <p>A token is requested once per authentication and repository url, and reused from an in-memory cache afterwards.
+ * Profile entries and service-credential entries never share a cache slot, and the credentials half of the key is a
+ * digest, so no secret is held in clear.
+ *
+ * <p>Gradle instantiates it through {@code sharedServices.registerIfAbsent}; there is no reason to construct one
+ * directly.
+ */
 public class CodeArtifactToken implements BuildService<None> {
 
   private final ConcurrentHashMap<String, String> tokensCache = new ConcurrentHashMap<>();
 
+  /**
+   * Creates the service. Called by Gradle, which owns the single instance registered for the build.
+   */
+  public CodeArtifactToken() {
+  }
+
+  /**
+   * Returns the authorization token for {@code uri}, authenticating with an AWS profile.
+   *
+   * @param uri     the CodeArtifact repository url
+   * @param profile the AWS profile to authenticate with, or {@code null} to let the AWS SDK resolve the credentials
+   * @return the authorization token, from the cache when this authentication and url were already resolved
+   * @throws MalformedURLException when {@code uri} is not a valid CodeArtifact repository url
+   */
   public String getToken(URI uri, String profile) throws MalformedURLException {
     return getToken(uri.toString(), profile);
   }
 
+  /**
+   * Returns the authorization token for {@code uri}, authenticating with an AWS profile.
+   *
+   * @param uri     the CodeArtifact repository url
+   * @param profile the AWS profile to authenticate with, or {@code null} to let the AWS SDK resolve the credentials
+   * @return the authorization token, from the cache when this authentication and url were already resolved
+   * @throws MalformedURLException when {@code uri} is not a valid CodeArtifact repository url
+   */
   public String getToken(String uri, String profile) throws MalformedURLException {
     CodeArtifactUrl codeArtifactUrl = CodeArtifactUrl.of(uri);
 
@@ -39,10 +71,26 @@ public class CodeArtifactToken implements BuildService<None> {
         k -> TokenFactory.getAuthorizationToken(codeArtifactUrl, profile).authorizationToken());
   }
 
+  /**
+   * Returns the authorization token for {@code uri}, authenticating with the static credentials of a service account.
+   *
+   * @param uri         the CodeArtifact repository url
+   * @param credentials the service account credentials to authenticate with
+   * @return the authorization token, from the cache when this authentication and url were already resolved
+   * @throws MalformedURLException when {@code uri} is not a valid CodeArtifact repository url
+   */
   public String getToken(URI uri, CodeArtifactCredentials credentials) throws MalformedURLException {
     return getToken(uri.toString(), credentials);
   }
 
+  /**
+   * Returns the authorization token for {@code uri}, authenticating with the static credentials of a service account.
+   *
+   * @param uri         the CodeArtifact repository url
+   * @param credentials the service account credentials to authenticate with
+   * @return the authorization token, from the cache when this authentication and url were already resolved
+   * @throws MalformedURLException when {@code uri} is not a valid CodeArtifact repository url
+   */
   public String getToken(String uri, CodeArtifactCredentials credentials) throws MalformedURLException {
     CodeArtifactUrl codeArtifactUrl = CodeArtifactUrl.of(uri);
 
@@ -51,6 +99,11 @@ public class CodeArtifactToken implements BuildService<None> {
         k -> TokenFactory.getAuthorizationToken(codeArtifactUrl, credentials).authorizationToken());
   }
 
+  /**
+   * {@inheritDoc}
+   *
+   * <p>The service takes no parameters.
+   */
   @Override
   public None getParameters() {
     return null;

--- a/src/main/java/ai/clarity/codeartifact/TokenFactory.java
+++ b/src/main/java/ai/clarity/codeartifact/TokenFactory.java
@@ -24,8 +24,26 @@ import software.amazon.awssdk.services.codeartifact.CodeartifactClient;
 import software.amazon.awssdk.services.codeartifact.CodeartifactClientBuilder;
 import software.amazon.awssdk.services.codeartifact.model.GetAuthorizationTokenResponse;
 
+/**
+ * Calls the CodeArtifact {@code GetAuthorizationToken} API.
+ *
+ * <p>Every overload issues a request; the caching lives in {@link CodeArtifactToken}.
+ */
 public class TokenFactory {
 
+  private TokenFactory() {
+    // Static-only utility
+  }
+
+  /**
+   * Requests the token for a repository url with the given AWS profile.
+   *
+   * @param codeArtifactUrl the CodeArtifact repository url
+   * @param profileName     the AWS profile to authenticate with, or {@code null} to use the default credentials
+   *                        provider chain
+   * @return the API response carrying the authorization token and its expiration
+   * @throws MalformedURLException when {@code codeArtifactUrl} is not a valid CodeArtifact repository url
+   */
   public static GetAuthorizationTokenResponse getAuthorizationToken(String codeArtifactUrl, String profileName)
     throws MalformedURLException {
     return getAuthorizationToken(CodeArtifactUrl.of(codeArtifactUrl), profileName);
@@ -34,6 +52,11 @@ public class TokenFactory {
   /**
    * Requests the token with the given AWS profile, or with the default credentials provider chain when
    * {@code profileName} is {@code null}.
+   *
+   * @param codeArtifactUrl the parsed CodeArtifact repository url, which carries the region the client targets
+   * @param profileName     the AWS profile to authenticate with, or {@code null} to use the default credentials
+   *                        provider chain
+   * @return the API response carrying the authorization token and its expiration
    */
   public static GetAuthorizationTokenResponse getAuthorizationToken(CodeArtifactUrl codeArtifactUrl, String profileName) {
     return requestToken(codeArtifactUrl, profileName == null ? null : ProfileCredentialsProvider.create(profileName));
@@ -41,6 +64,10 @@ public class TokenFactory {
 
   /**
    * Requests the token with the static credentials of a service account, bypassing the local AWS profiles.
+   *
+   * @param codeArtifactUrl the parsed CodeArtifact repository url, which carries the region the client targets
+   * @param credentials     the service account credentials to authenticate with
+   * @return the API response carrying the authorization token and its expiration
    */
   public static GetAuthorizationTokenResponse getAuthorizationToken(CodeArtifactUrl codeArtifactUrl,
                                                                     CodeArtifactCredentials credentials) {

--- a/src/main/java/ai/clarity/codeartifact/URIBuilder.java
+++ b/src/main/java/ai/clarity/codeartifact/URIBuilder.java
@@ -21,6 +21,13 @@ import java.util.LinkedHashMap;
 import java.util.Map;
 import java.util.stream.Collectors;
 
+  /**
+   * Mutable builder for editing the parts of a {@link URI}, used here to read and strip the {@code ?profile=} query
+   * parameter of a repository url without rebuilding the string by hand.
+   *
+   * <p>Query parameters keep their insertion order, and a parameter present with no {@code =} is held with a
+   * {@code null} value so that it survives a round trip.
+   */
 public class URIBuilder {
 
   private String scheme;
@@ -36,6 +43,12 @@ public class URIBuilder {
 
   }
 
+  /**
+   * Creates a builder holding every component of {@code uri}.
+   *
+   * @param uri the uri to read
+   * @return a builder initialised from {@code uri}
+   */
   public static URIBuilder of(URI uri) {
     return new URIBuilder()
       .withScheme(uri.getScheme())
@@ -48,60 +61,137 @@ public class URIBuilder {
       .withQuery(uri.getQuery());
   }
 
+  /**
+   * Sets the scheme component.
+   *
+   * @param scheme the scheme, such as {@code https}
+   * @return this builder
+   */
   public URIBuilder withScheme(String scheme) {
     this.scheme = scheme;
     return this;
   }
 
+  /**
+   * Sets the fragment component.
+   *
+   * @param fragment the fragment, without the leading {@code #}
+   * @return this builder
+   */
   public URIBuilder withFragment(String fragment) {
     this.fragment = fragment;
     return this;
   }
 
+  /**
+   * Sets the authority component.
+   *
+   * @param authority the authority
+   *
+   * <p>Note {@link #toURI()} rebuilds the authority from the user info, host and port instead of using this
+   * value, so setting it alone does not change the uri produced.
+   * @return this builder
+   */
   public URIBuilder withAuthority(String authority) {
     this.authority = authority;
     return this;
   }
 
+  /**
+   * Sets the userInfo component.
+   *
+   * @param userInfo the user info, without the trailing {@code @}
+   * @return this builder
+   */
   public URIBuilder withUserInfo(String userInfo) {
     this.userInfo = userInfo;
     return this;
   }
 
+  /**
+   * Sets the host component.
+   *
+   * @param host the host
+   * @return this builder
+   */
   public URIBuilder withHost(String host) {
     this.host = host;
     return this;
   }
 
+  /**
+   * Sets the port component.
+   *
+   * @param port the port, or {@code -1} for none
+   * @return this builder
+   */
   public URIBuilder withPort(int port) {
     this.port = port;
     return this;
   }
 
+  /**
+   * Sets the path component.
+   *
+   * @param path the path, with its leading {@code /}
+   * @return this builder
+   */
   public URIBuilder withPath(String path) {
     this.path = path;
     return this;
   }
 
+  /**
+   * Replaces every query parameter with the ones parsed from {@code query}.
+   *
+   * @param query the raw query string, without the leading {@code ?}; {@code null} clears the parameters
+   * @return this builder
+   */
   public URIBuilder withQuery(String query) {
     queryParams = parseQueryParams(query);
     return this;
   }
 
+  /**
+   * Returns the value of one query parameter.
+   *
+   * @param param the parameter name
+   * @return its value, {@code null} when the parameter is absent <em>or</em> present without a value
+   */
   public String getQueryParamValue(String param) {
     return queryParams.get(param);
   }
 
+  /**
+   * Removes one query parameter, doing nothing when it is absent.
+   *
+   * @param param the parameter name
+   * @return this builder
+   */
   public URIBuilder removeQueryParam(String param) {
     queryParams.remove(param);
     return this;
   }
 
+  /**
+   * Sets one query parameter, replacing any previous value and keeping the original position when it was already
+   * present.
+   *
+   * @param param the parameter name
+   * @param value its value, or {@code null} to render the parameter with no {@code =}
+   * @return this builder
+   */
   public URIBuilder setQueryParam(String param, String value) {
     queryParams.put(param, value);
     return this;
   }
 
+  /**
+   * Builds the uri from the components held by this builder.
+   *
+   * @return the resulting uri, with the query rendered from the current parameters
+   * @throws URISyntaxException when the components do not form a valid uri
+   */
   public URI toURI() throws URISyntaxException {
     String query = generateQueryByParams();
     return new URI(scheme, userInfo, host, port, path, query, fragment);
@@ -152,34 +242,75 @@ public class URIBuilder {
     return params;
   }
 
+  /**
+   * Returns the scheme component.
+   *
+   * @return the scheme
+   */
   public String getScheme() {
     return scheme;
   }
 
+  /**
+   * Returns the fragment component.
+   *
+   * @return the fragment
+   */
   public String getFragment() {
     return fragment;
   }
 
+  /**
+   * Returns the authority component.
+   *
+   * @return the authority as read from the original uri; see {@link #withAuthority(String)} for why
+   *         {@link #toURI()} ignores it
+   */
   public String getAuthority() {
     return authority;
   }
 
+  /**
+   * Returns the user info component.
+   *
+   * @return the user info
+   */
   public String getUserInfo() {
     return userInfo;
   }
 
+  /**
+   * Returns the host component.
+   *
+   * @return the host
+   */
   public String getHost() {
     return host;
   }
 
+  /**
+   * Returns the port component.
+   *
+   * @return the port, or {@code -1} when there is none
+   */
   public int getPort() {
     return port;
   }
 
+  /**
+   * Returns the path component.
+   *
+   * @return the path
+   */
   public String getPath() {
     return path;
   }
 
+  /**
+   * Renders the current query parameters back into a query string.
+   *
+   * @return the query string, without the leading {@code ?}, or {@code null} when there are no parameters
+   */
   public String getQuery() {
     return generateQueryByParams();
   }


### PR DESCRIPTION
Fills all 43 javadoc warnings and adds `-Werror` so they cannot come back.

Closes #821.

## Why it mattered

`javadoc` is in the `build` task graph, so the 43 lines scrolled past on every local build and every CI run — the kind of steady noise that hides a real warning. They also shipped: `javadocJar` is part of the publication, so the gaps were what a consumer saw in their IDE.

| File | Was |
|---|---|
| `URIBuilder.java` | 22 |
| `TokenFactory.java` | 9 |
| `CodeArtifactToken.java` | 6 |
| `CodeArtifactCredentials.java` | 6 |

Now zero, in `javadoc` and in a full `build`.

## Two that were a design signal, not a doc one

`use of default constructor` is javadoc pointing at an implicit public constructor, and writing a comment for it would have been the wrong fix:

- **`TokenFactory`** is a static-only utility, so it gets a **private constructor** rather than a doc comment for an instantiation nobody wants.
- **`CodeArtifactToken`** is a Gradle `BuildService`, which Gradle instantiates itself, so it gets an explicit documented no-arg constructor.

## Three subtleties now recorded on the members

Writing the docs forced reading the code, which turned up behaviour worth pinning down in `URIBuilder`:

- `toURI()` rebuilds the authority from the user info, host and port, and **ignores** whatever `withAuthority` was given — so setting it alone changes nothing. Noted on both `withAuthority` and `getAuthority`.
- `getQueryParamValue` returns `null` both for an absent parameter **and** for one present without a value. The two cases are indistinguishable to a caller.
- `getQuery()` re-renders from the parameter map rather than returning a stored string, unlike every other getter.

No behaviour changed; these are comments on what the code already does.

## The gate

```kotlin
tasks.javadoc {
  (options as StandardJavadocDocletOptions).addBooleanOption("Werror", true)
}
```

Verified by deleting one comment and re-running: `error: warnings found and -Werror specified`, `BUILD FAILED`.

Worth being deliberate about: **this is the repo's first automated style gate.** `check` still has no linter or formatter, and Kotlin is not covered — there is no Dokka and no KDoc jar in the publication, which #821 left explicitly out of scope. `AGENTS.md` is updated to say exactly that, so the next person does not read "no linter configured" and get surprised by a javadoc failure.

## Testing

`./gradlew build` green: 105 unit, 106 functional, `validatePlugins`, and `javadoc` clean.

Existing prose was left alone — `CodeArtifactCredentials.of(Map)`, `getMaskedAccessKeyId()` and the two documented `TokenFactory` overloads already read well and only needed their `@param`/`@return` half.
