### PR TITLE
chore: prepare 0.2.2

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -34,7 +34,7 @@ All verified on this checkout (`main`, 2026-09-01).
 
 ```bash
 ./gradlew build            # compile + unit tests + functionalTest + validatePlugins
-./gradlew test             # 102 unit tests
+./gradlew test             # 105 unit tests
 ./gradlew functionalTest   # 106 TestKit tests across Gradle 8.4, 8.7, 8.14, 9.1.0, 9.4.0
 ./gradlew publishToMavenLocal   # for trying the plugin from a scratch project
 ./gradlew tasks --all

--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ In your `build.gradle.kts` file:
 
 ```kotlin
 plugins {
-  id("ai.clarity.codeartifact") version "0.2.1"
+  id("ai.clarity.codeartifact") version "0.2.2"
 }
 
 repositories {
@@ -50,7 +50,7 @@ In your `build.gradle.kts` file:
 
 ```kotlin
 plugins {
-  id("ai.clarity.codeartifact") version "0.2.1"
+  id("ai.clarity.codeartifact") version "0.2.2"
 }
 
 publishing {
@@ -70,7 +70,7 @@ In your `build.gradle` file:
 
 ```groovy
 plugins {
-    id 'ai.clarity.codeartifact' version '0.2.1'
+    id 'ai.clarity.codeartifact' version '0.2.2'
 }
 
 repositories {
@@ -86,7 +86,7 @@ In your `build.gradle` file:
 
 ```groovy
 plugins {
-    id 'ai.clarity.codeartifact' version '0.2.1'
+    id 'ai.clarity.codeartifact' version '0.2.2'
 }
 
 publishing {
@@ -175,7 +175,7 @@ In your `settings.gradle.kts` file:
 
 ```kotlin
 plugins {
-  id("ai.clarity.codeartifact") version "0.2.1"
+  id("ai.clarity.codeartifact") version "0.2.2"
 }
 
 dependencyResolutionManagement {
@@ -193,7 +193,7 @@ In your `settings.gradle.kts` file:
 
 ```kotlin
 plugins {
-  id("ai.clarity.codeartifact") version "0.2.1"
+  id("ai.clarity.codeartifact") version "0.2.2"
 }
 
 pluginManagement {
@@ -213,7 +213,7 @@ In your `settings.gradle` file:
 
 ```groovy
 plugins {
-    id 'ai.clarity.codeartifact' version '0.2.1'
+    id 'ai.clarity.codeartifact' version '0.2.2'
 }
 
 dependencyResolutionManagement {
@@ -231,7 +231,7 @@ In your `settings.gradle` file:
 
 ```groovy
 plugins {
-    id 'ai.clarity.codeartifact' version '0.2.1'
+    id 'ai.clarity.codeartifact' version '0.2.2'
 }
 
 pluginManagement {

--- a/docs/ONBOARDING.md
+++ b/docs/ONBOARDING.md
@@ -111,7 +111,7 @@ Gradle cannot run inside the Claude Code sandbox — disable it for every `./gra
 
 ```kotlin
 // build.gradle.kts
-plugins { id("ai.clarity.codeartifact") version "0.2.1" }
+plugins { id("ai.clarity.codeartifact") version "0.2.2" }
 repositories {
   maven { url = uri("https://my-domain-111122223333.d.codeartifact.us-west-2.amazonaws.com/maven/my-repo/") }
 }
@@ -239,7 +239,7 @@ reaches build scans, caches and logs. What the plugin does guarantee, all verifi
 ## 6. Testing
 
 ```bash
-./gradlew test --rerun-tasks            # 102 tests, all green
+./gradlew test --rerun-tasks            # 105 tests, all green
 ./gradlew functionalTest --rerun-tasks  # 106 tests, all green
 ./gradlew build                         # both + validatePlugins; ~4m from clean
 ```


### PR DESCRIPTION
Release preparation for **0.2.2**. Docs only — no source change.

Bumps the nine `version "0.2.1"` pins in the README and `docs/ONBOARDING.md` to `0.2.2`, so anyone copy-pasting an example after the release gets the version that is actually out, and corrects the unit-test count to 105 after #822 and #824.

Merge this before running `./gradlew release`, so the tag carries the right pins.

## What 0.2.2 contains

Two fixes, both to behaviour 0.2.1 got wrong:

* **Dualstack endpoints work** (#822). They were unusable by either path: `CodeArtifactUrl` rejected every real dualstack URL and automatic detection skipped it in silence. The host shape had been assumed rather than checked — the real one is `{domain}-{owner}.codeartifact.{region}.on.aws`, with no `.d.` segment.
* **The Java public surface is documented** (#824), and `javadoc -Werror` keeps it that way. The 43 missing comments were shipping in the javadoc jar.

Plus the AWS SDK BOM bump to 2.54.7 (#823).

The 0.2.0 and 0.2.1 release notes have already been corrected: both claimed the `codeartifact()` helper accepted dualstack URLs, which it did not.
